### PR TITLE
fix: curl 解析（extract_from_curl 截断 + payload 非法 JSON 兜底）

### DIFF
--- a/lib/client.lua
+++ b/lib/client.lua
@@ -70,6 +70,35 @@ function Client:json_decode(text)
     return json:decode(text)
 end
 
+--- Parse the --data-raw payload of a /web/book/read cURL into a table.
+-- WeRead's web client occasionally emits unescaped quotes inside string values
+-- (e.g. a book title snippet in "sm"), so the captured payload may not be valid
+-- JSON. In that case, fall back to extracting the scalar fields read-report
+-- needs by pattern matching, instead of silently dropping the whole payload.
+function Client:parse_read_payload(text)
+    if not text or text == "" then
+        return nil
+    end
+    local ok, payload = pcall(function()
+        return self:json_decode(text)
+    end)
+    if ok and type(payload) == "table" then
+        return payload
+    end
+    local fallback = {}
+    fallback.appId = text:match('"appId"%s*:%s*"([^"]*)"')
+    fallback.c     = text:match('"c"%s*:%s*"([^"]*)"')
+    fallback.ci    = tonumber(text:match('"ci"%s*:%s*(%d+)'))
+    fallback.co    = tonumber(text:match('"co"%s*:%s*(%d+)'))
+    fallback.pr    = tonumber(text:match('"pr"%s*:%s*(%d+)'))
+    fallback.ps    = text:match('"ps"%s*:%s*"([^"]*)"')
+    fallback.pc    = text:match('"pc"%s*:%s*"([^"]*)"')
+    if not next(fallback) then
+        return nil
+    end
+    return fallback
+end
+
 function Client:request(opts)
     local body = opts.body
     local response = {}

--- a/lib/cookie.lua
+++ b/lib/cookie.lua
@@ -20,12 +20,21 @@ function Cookie.extract_from_curl(curl)
         return "", nil
     end
 
-    local cookie = curl:match("%-H%s+['\"][Cc]ookie:%s*(.-)['\"]")
-        or curl:match("%-b%s+['\"](.-)['\"]")
-        or curl:match("%-%-cookie%s+['\"](.-)['\"]")
-    local data = curl:match("%-%-data%-raw%s+['\"](.-)['\"]")
-        or curl:match("%-%-data%s+['\"](.-)['\"]")
-        or curl:match("%-d%s+['\"](.-)['\"]")
+    -- Match the value inside *matching* single/double quotes: capture the opening
+    -- quote and require the same quote to close it (back-reference %1). A plain
+    -- ['\"](.-)['\"] stops at the first internal quote, so a JSON payload like
+    -- --data-raw '{"appId":"…"}' was captured as just "{".
+    local function quoted(pattern)
+        local _opening_quote, value = curl:match(pattern)
+        return value
+    end
+
+    local cookie = quoted("%-H%s+(['\"])[Cc]ookie:%s*(.-)%1")
+        or quoted("%-b%s+(['\"])(.-)%1")
+        or quoted("%-%-cookie%s+(['\"])(.-)%1")
+    local data = quoted("%-%-data%-raw%s+(['\"])(.-)%1")
+        or quoted("%-%-data%s+(['\"])(.-)%1")
+        or quoted("%-d%s+(['\"])(.-)%1")
 
     return cookie or curl, data
 end

--- a/main.lua
+++ b/main.lua
@@ -107,10 +107,8 @@ function WeReadPlugin:loadConfigFile()
     end
 
     if curl_payload and curl_payload ~= "" then
-        local parsed_ok, payload = pcall(function()
-            return self.client:json_decode(curl_payload)
-        end)
-        if parsed_ok and type(payload) == "table" then
+        local payload = self.client:parse_read_payload(curl_payload)
+        if payload then
             self.settings:set("curl_payload", payload)
         end
     end
@@ -538,10 +536,8 @@ function WeReadPlugin:showImportCookieDialog()
                         end
                         self.settings:set("cookies", cookies)
                         if curl_data and curl_data ~= "" then
-                            local ok, payload = pcall(function()
-                                return self.client:json_decode(curl_data)
-                            end)
-                            if ok and type(payload) == "table" then
+                            local payload = self.client:parse_read_payload(curl_data)
+                            if payload then
                                 self.settings:set("curl_payload", payload)
                             end
                         end


### PR DESCRIPTION
## 背景

把插件部署到 Kindle（KOReader v2026.03）后，发现「阅读时长上报」一直拿不到真实的 `appId` / `ps` / `pc`（防作弊签名 token），上报会被微信读书服务器拒收。排查发现是 curl 解析链路有两个独立问题。

## Bug 1：`extract_from_curl` 抓 `--data-raw` 只得到 `{`

`lib/cookie.lua` 用惰性匹配 `['\"](.-)['\"]` 收尾，遇到 JSON 内部第一个 `"` 就截断：

```lua
-- 旧写法：对  --data-raw '{"appId":"wb...","ps":"..."}'  只抓到 "{"
local data = curl:match("%-%-data%-raw%s+['\"](.-)['\"]")
```

后果：`curl_payload` 的 JSON 解析失败，`doReadReport` 拿不到真实字段，只能退回兜底值（`appId` 走 `web_app_id()`、`ps` 走 `e(now-1)`），服务器拒收。

**修复**：用反向引用 `%1` 配对引号——捕获开引号、要求**同一种**引号收尾，这样值里包含另一种引号也能完整抓到。`-H/-b/--cookie` 和 `--data-raw/--data/-d` 两组模式都改了。

## Bug 2：WeRead 网页 payload 的字符串值含未转义引号

从 `weread.qq.com` 的 `/web/book/read` 复制出来的 `--data-raw`，`sm`（书名内容片段）里直接带了未转义的 ASCII 引号，是**非法 JSON**：

```json
"sm":"版权信息书名：被讨厌的勇气："自我启发"
```

`json.decode` 直接抛错，而外层 `pcall` 把错误吞掉，`curl_payload` 被静默丢弃、没有任何提示。两个入口都中招：启动时的 `loadConfigFile` 和菜单「导入 Cookie/cURL」。

**修复**：新增 `Client:parse_read_payload(text)`——先试 `json_decode`，失败时用 pattern 把 read-report 需要的标量字段（`appId` / `c` / `ci` / `co` / `pr` / `ps` / `pc`）逐个抠出来，而不是整包丢弃。两个入口都改用它（顺带去重了逻辑）。

## 验证

- 三个文件 `luajit -bl` 语法通过
- 本地测试（用真实 curl / payload）：
  - Bug1：`--data-raw '{"appId":"…"}'` 现在能完整抓到，不再截断成 `{`
  - Bug2：对上面的非法 payload，兜底能正确抠出 `appId=wb115321887466h850717700`、`ps=adf327107a9e3abag019f0c`、`pc=a7932d507a9e3abbg010332`
- Kindle 上部署后实测：`settings/weread.lua` 里的 `curl_payload` 现在能正确持久化全部字段

## 改动

- `lib/cookie.lua`：`extract_from_curl` 改用配对引号
- `lib/client.lua`：新增 `parse_read_payload`
- `main.lua`：两处 payload 解析改用上面的方法

两个 commit 分别对应两个 bug，方便按需合入。如果只想要 Bug1 的修复合入，可以只 cherry-pick 第一个 commit。
