### PR TITLE
feat: add book footnote conversion

### DIFF
--- a/weread/lib/annotations.lua
+++ b/weread/lib/annotations.lua
@@ -6,7 +6,7 @@
 --]] --
 
 local logger = require("logger")
-local Footnotes = require("lib.footnotes")
+local Footnotes = require("weread.lib.footnotes")
 
 local Annotations = {}
 

--- a/weread/lib/annotations.lua
+++ b/weread/lib/annotations.lua
@@ -6,6 +6,7 @@
 --]] --
 
 local logger = require("logger")
+local Footnotes = require("lib.footnotes")
 
 local Annotations = {}
 
@@ -331,76 +332,103 @@ function Annotations.injectUnderlines(html, underlines, thought_reviews, chapter
 
     logger.info("weread annotations: html runes=", n, "underlines=", #ranges)
 
-    -- 预计算所有替换片段
-    local replacements = {}
-    local prevEnd = 0
+    local protected_spans = Footnotes.find_footnote_spans(html)
 
-    for _, ul in ipairs(ranges) do
-        local start_pos = ul.start
-        local end_pos = ul.end_pos
-
-        -- 边界检查
-        if start_pos < 0 or end_pos > n or start_pos >= end_pos then
-            goto continue
+    local function intersectingProtected(start_pos, end_pos)
+        local hits = {}
+        for _, prot in ipairs(protected_spans) do
+            if prot.start < end_pos and prot.end_pos > start_pos then
+                hits[#hits + 1] = {
+                    start = math.max(start_pos, prot.start),
+                    end_pos = math.min(end_pos, prot.end_pos),
+                }
+            end
         end
+        table.sort(hits, function(a, b) return a.start < b.start end)
+        return hits
+    end
 
-        -- 校正边界：确保 start 和 end 不落在 HTML 标签或实体内部
-        end_pos = snapEndToSafeBoundary(runes, start_pos, end_pos)
-        start_pos = snapStartToSafeBoundary(runes, start_pos, end_pos)
+    local function wrapRunesSlice(slice_start, slice_end, range_str, with_thought)
+        if slice_start >= slice_end then return {} end
 
-        -- 确保不重叠
-        if start_pos >= end_pos or start_pos < prevEnd then
-            goto continue
-        end
-
-        -- 提取范围内的内容并包裹下划线标签
         local inner = {}
-        for j = start_pos, end_pos - 1 do
+        for j = slice_start, slice_end - 1 do
             inner[#inner + 1] = runes[j]
         end
 
-        -- 使用 wrapTextSegments 处理跨标签边界
         local wrapped = wrapTextSegments(inner, "wr-underline")
+        if not with_thought then
+            return wrapped
+        end
 
-        -- 如果有想法数据，每个 wr-underline span 单独包裹 <a>（跨段可点击）
-        if thought_reviews and thought_reviews[ul.range_str] then
-            local underline_open = '<span class="wr-underline">'
-            local underline_close = '</span>'
-            local underline_close_with_ref = '<span class="wr-star">*</span></span>'
+        local underline_open = '<span class="wr-underline">'
+        local underline_close = '</span>'
+        local underline_close_with_ref = '<span class="wr-star">*</span></span>'
 
-            -- 星号注入到最后一个 underline span 末尾
-            local last_idx = #wrapped
-            if wrapped[last_idx] == underline_close then
-                wrapped[last_idx] = underline_close_with_ref
+        local last_idx = #wrapped
+        if wrapped[last_idx] == underline_close then
+            wrapped[last_idx] = underline_close_with_ref
+        end
+
+        local anchor_id = thoughtAnchorId(book_id, chapter_uid, range_str)
+        local href = "#" .. anchor_id
+        local open_a = '<a class="wr-thought-link" href="' .. htmlEscape(href) .. '">'
+        local open_a_with_id = '<a id="' .. htmlEscape(anchor_id)
+            .. '" class="wr-thought-link" href="' .. htmlEscape(href) .. '">'
+
+        local with_links = {}
+        local first_link = true
+        for _, item in ipairs(wrapped) do
+            if item == underline_open then
+                with_links[#with_links + 1] = first_link and open_a_with_id or open_a
+                first_link = false
+                with_links[#with_links + 1] = item
+            elseif item == underline_close or item == underline_close_with_ref then
+                with_links[#with_links + 1] = item
+                with_links[#with_links + 1] = '</a>'
+            else
+                with_links[#with_links + 1] = item
             end
+        end
+        return with_links
+    end
 
-            -- 内部锚点（非 noteref）：去掉 epub:type="noteref" 避免 crengine 走专用
-            -- 脚注弹窗路径（该路径无视 CSS pointer-events）。想法内容不再内嵌 EPUB，
-            -- 点击时由 main.lua 从缓存 JSON 现取。锚点已编码 book_id+chapter_uid+range。
-            local anchor_id = thoughtAnchorId(book_id, chapter_uid, ul.range_str)
-            local href = "#" .. anchor_id
-            local open_a = '<a class="wr-thought-link" href="' .. htmlEscape(href) .. '">'
-            -- 只第一个 <a> 带 id：拦截失败时 KOReader 跟随锚点最多跳回划线起点（兜底）。
-            local open_a_with_id = '<a id="' .. htmlEscape(anchor_id)
-                .. '" class="wr-thought-link" href="' .. htmlEscape(href) .. '">'
+    -- 预计算所有替换片段
+    local replacements = {}
+    local prevEnd = 1
 
-            -- wrapTextSegments 为每个文本段生成独立的 underline span；
-            -- 逐 span 包裹 <a> 可避免 </h1><p>、</p><p> 等块级边界导致 MuPDF 截断链接。
-            local with_links = {}
-            local first_link = true
-            for _, item in ipairs(wrapped) do
-                if item == underline_open then
-                    with_links[#with_links + 1] = first_link and open_a_with_id or open_a
-                    first_link = false
-                    with_links[#with_links + 1] = item
-                elseif item == underline_close or item == underline_close_with_ref then
-                    with_links[#with_links + 1] = item
-                    with_links[#with_links + 1] = '</a>'
-                else
-                    with_links[#with_links + 1] = item
+    local function processOne(ul)
+        local start_pos = ul.start
+        local end_pos = ul.end_pos
+
+        if start_pos < 1 or end_pos > n + 1 or start_pos >= end_pos then return end
+
+        end_pos = snapEndToSafeBoundary(runes, start_pos, end_pos)
+        start_pos = snapStartToSafeBoundary(runes, start_pos, end_pos)
+
+        if start_pos >= end_pos or start_pos < prevEnd then return end
+
+        local with_thought = thought_reviews and thought_reviews[ul.range_str] or false
+        local protected = intersectingProtected(start_pos, end_pos)
+        local wrapped = {}
+        local pos = start_pos
+
+        for _, prot in ipairs(protected) do
+            if prot.start > pos then
+                for _, item in ipairs(wrapRunesSlice(pos, prot.start, ul.range_str, with_thought)) do
+                    wrapped[#wrapped + 1] = item
                 end
             end
-            wrapped = with_links
+            for j = prot.start, prot.end_pos - 1 do
+                wrapped[#wrapped + 1] = runes[j]
+            end
+            pos = prot.end_pos
+        end
+
+        if pos < end_pos then
+            for _, item in ipairs(wrapRunesSlice(pos, end_pos, ul.range_str, with_thought)) do
+                wrapped[#wrapped + 1] = item
+            end
         end
 
         replacements[#replacements + 1] = {
@@ -409,8 +437,10 @@ function Annotations.injectUnderlines(html, underlines, thought_reviews, chapter
             content = wrapped,
         }
         prevEnd = end_pos
+    end
 
-        ::continue::
+    for _, ul in ipairs(ranges) do
+        processOne(ul)
     end
 
     if #replacements == 0 then

--- a/weread/lib/content.lua
+++ b/weread/lib/content.lua
@@ -1017,12 +1017,7 @@ local function footnote_meta(client, settings, book, state)
             return Content.fetch_chapter_xhtml(client, settings, book, chapter)
         end,
         fetch_catalog = function()
-            local book_id = book.book_id or book.bookId
-            local reader_url = book.reader_url or WeRead.reader_url(book_id)
-            local catalog = client:post_json("https://weread.qq.com/web/book/chapterInfos", {
-                bookIds = { tostring(book_id) },
-            }, { referer = reader_url })
-            return Content.normalize_chapters(catalog, book_id)
+            return Content.fetch_catalog(client, book)
         end,
     }
 end
@@ -1086,31 +1081,6 @@ function Content.fetch_chapter_epub(client, settings, book, chapter)
     return path, chapter
 end
 
-function Content.fetch_single_chapter_content(client, settings, book, chapter, state)
-    state = state or {}
-    local xhtml = Content.fetch_chapter_xhtml(client, settings, book, chapter)
-    if not state.css then
-        state.css = Content.fetch_chapter_css(client, settings, book, chapter)
-    end
-    xhtml, state.css = apply_chapter_enrichments(client, settings, book, chapter, xhtml, state.css, state)
-    local chapter_assets = {}
-    local cache = settings:get("cache", {})
-    if cache.download_book_images then
-        state.used_asset_names = state.used_asset_names or {}
-        local tar_assets, src_map = Content.download_chapter_assets(client, book, chapter, state.used_asset_names)
-        for _, asset in ipairs(tar_assets) do
-            table.insert(chapter_assets, asset)
-        end
-        xhtml = Content.rewrite_image_sources(xhtml, src_map)
-        local inline_xhtml, inline_assets = Content.download_remote_images(client, xhtml, state.used_asset_names)
-        xhtml = inline_xhtml
-        for _, a in ipairs(inline_assets) do
-            table.insert(chapter_assets, a)
-        end
-    end
-    return xhtml, chapter_assets
-end
-
 -- Split chapter downloading around annotation fetching so the UI can request
 -- thought batches cooperatively instead of blocking inside Thoughts.apply().
 function Content.fetch_single_chapter_source(client, settings, book, chapter, state)
@@ -1124,6 +1094,12 @@ end
 
 function Content.finalize_single_chapter_content(client, settings, book, chapter, xhtml, state)
     state = state or {}
+    -- Apply footnotes (image-based and cross-file). The downloader pipeline
+    -- applies annotations separately; footnotes are handled here so they
+    -- run regardless of annotation settings.
+    local new_css
+    xhtml, new_css = apply_chapter_footnotes(client, settings, book, chapter, xhtml, state.css, state)
+    state.css = new_css
     local chapter_assets = {}
     local cache = settings:get("cache", {})
     if cache.download_book_images then

--- a/weread/lib/content.lua
+++ b/weread/lib/content.lua
@@ -1049,6 +1049,7 @@ local function apply_chapter_footnotes(client, settings, book, chapter, xhtml, c
 end
 
 local function apply_chapter_enrichments(client, settings, book, chapter, xhtml, css, state)
+    xhtml = Footnotes.normalize_markup(xhtml)
     xhtml, css = apply_chapter_annotations(client, settings, book, chapter, xhtml, css)
     xhtml, css = apply_chapter_footnotes(client, settings, book, chapter, xhtml, css, state)
     return xhtml, css
@@ -1089,6 +1090,9 @@ function Content.fetch_single_chapter_source(client, settings, book, chapter, st
     local xhtml = Content.fetch_chapter_xhtml(client, settings, book, chapter)
     if not state.css then
         state.css = Content.fetch_chapter_css(client, settings, book, chapter)
+    end
+    if book._content_format ~= "txt" then
+        xhtml = Footnotes.normalize_markup(xhtml)
     end
     return xhtml
 end

--- a/weread/lib/content.lua
+++ b/weread/lib/content.lua
@@ -1013,6 +1013,7 @@ local function footnote_meta(client, settings, book, state)
         book_dir = Content.book_cache_dir(settings, book_id),
         book_id = book_id,
         is_txt = book._content_format == "txt",
+        chapters = state.chapters,
         fetch_chapter_html = function(chapter)
             return Content.fetch_chapter_xhtml(client, settings, book, chapter)
         end,

--- a/weread/lib/content.lua
+++ b/weread/lib/content.lua
@@ -1,8 +1,8 @@
-local Crypto = require("lib.crypto")
-local ReaderState = require("lib.reader_state")
-local WeRead = require("lib.weread")
-local Thoughts = require("lib.thoughts")
-local Footnotes = require("lib.footnotes")
+local Crypto = require("weread.lib.crypto")
+local ReaderState = require("weread.lib.reader_state")
+local WeRead = require("weread.lib.protocol")
+local Thoughts = require("weread.lib.thoughts")
+local Footnotes = require("weread.lib.footnotes")
 local bit = require("bit")
 local ok_logger, logger = pcall(require, "logger")
 if not ok_logger then

--- a/weread/lib/content.lua
+++ b/weread/lib/content.lua
@@ -1,7 +1,8 @@
-local Crypto = require("weread.lib.crypto")
-local ReaderState = require("weread.lib.reader_state")
-local WeRead = require("weread.lib.protocol")
-local Thoughts = require("weread.lib.thoughts")
+local Crypto = require("lib.crypto")
+local ReaderState = require("lib.reader_state")
+local WeRead = require("lib.weread")
+local Thoughts = require("lib.thoughts")
+local Footnotes = require("lib.footnotes")
 local bit = require("bit")
 local ok_logger, logger = pcall(require, "logger")
 if not ok_logger then
@@ -994,6 +995,38 @@ function Content.fetch_chapter_css(client, settings, book, chapter)
 end
 
 
+local function append_before_body_close(xhtml, fragment)
+    if type(fragment) ~= "string" or fragment == "" then
+        return xhtml
+    end
+    local pos = xhtml:lower():find("</body>", 1, true)
+    if pos then
+        return xhtml:sub(1, pos - 1) .. fragment .. xhtml:sub(pos)
+    end
+    return xhtml .. fragment
+end
+
+local function footnote_meta(client, settings, book, state)
+    state = state or {}
+    local book_id = book.book_id or book.bookId
+    return {
+        book_dir = Content.book_cache_dir(settings, book_id),
+        book_id = book_id,
+        is_txt = book._content_format == "txt",
+        fetch_chapter_html = function(chapter)
+            return Content.fetch_chapter_xhtml(client, settings, book, chapter)
+        end,
+        fetch_catalog = function()
+            local book_id = book.book_id or book.bookId
+            local reader_url = book.reader_url or WeRead.reader_url(book_id)
+            local catalog = client:post_json("https://weread.qq.com/web/book/chapterInfos", {
+                bookIds = { tostring(book_id) },
+            }, { referer = reader_url })
+            return Content.normalize_chapters(catalog, book_id)
+        end,
+    }
+end
+
 local function apply_chapter_annotations(client, settings, book, chapter, xhtml, css)
     local cache = settings:get("cache", {})
     if cache.download_underlines_and_thoughts ~= true then
@@ -1005,11 +1038,31 @@ local function apply_chapter_annotations(client, settings, book, chapter, xhtml,
     return processed, Thoughts.merge_css(css, annotation_css)
 end
 
+local function apply_chapter_footnotes(client, settings, book, chapter, xhtml, css, state)
+    if book._content_format == "txt" then
+        return xhtml, css
+    end
+    local processed, section = Footnotes.process(xhtml, footnote_meta(client, settings, book, state))
+    if section and section ~= "" then
+        processed = append_before_body_close(processed, section)
+    end
+    if processed ~= xhtml or (section and section ~= "") then
+        css = Thoughts.merge_css(css, Footnotes.FOOTNOTES_CSS)
+    end
+    return processed, css
+end
+
+local function apply_chapter_enrichments(client, settings, book, chapter, xhtml, css, state)
+    xhtml, css = apply_chapter_annotations(client, settings, book, chapter, xhtml, css)
+    xhtml, css = apply_chapter_footnotes(client, settings, book, chapter, xhtml, css, state)
+    return xhtml, css
+end
+
 function Content.fetch_chapter_epub(client, settings, book, chapter)
     local book_id = book.book_id or book.bookId
     local xhtml = Content.fetch_chapter_xhtml(client, settings, book, chapter)
     local css = Content.fetch_chapter_css(client, settings, book, chapter)
-    xhtml, css = apply_chapter_annotations(client, settings, book, chapter, xhtml, css)
+    xhtml, css = apply_chapter_enrichments(client, settings, book, chapter, xhtml, css, { chapters = book.chapters })
     local assets = {}
     local cache = settings:get("cache", {})
     if cache.download_book_images then
@@ -1039,7 +1092,7 @@ function Content.fetch_single_chapter_content(client, settings, book, chapter, s
     if not state.css then
         state.css = Content.fetch_chapter_css(client, settings, book, chapter)
     end
-    xhtml, state.css = apply_chapter_annotations(client, settings, book, chapter, xhtml, state.css)
+    xhtml, state.css = apply_chapter_enrichments(client, settings, book, chapter, xhtml, state.css, state)
     local chapter_assets = {}
     local cache = settings:get("cache", {})
     if cache.download_book_images then
@@ -1105,7 +1158,7 @@ function Content.fetch_chapters_epub(client, settings, book, chapters, options)
         if not css then
             css = Content.fetch_chapter_css(client, settings, book, chapter)
         end
-        xhtml, css = apply_chapter_annotations(client, settings, book, chapter, xhtml, css)
+        xhtml, css = apply_chapter_enrichments(client, settings, book, chapter, xhtml, css, { chapters = chapters })
         if cache.download_book_images then
             if options.progress then
                 options.progress(chapter_index, #chapters, chapter, "images")

--- a/weread/lib/downloader.lua
+++ b/weread/lib/downloader.lua
@@ -175,7 +175,7 @@ function Downloader:start(book, chapters, suffix, options)
             selected = {},
             bodies = {},
             assets = {},
-            state = {},
+            state = { chapters = chapters },
             total = total,
             failed = {},
             annotation_failed_batches = 0,

--- a/weread/lib/footnotes.lua
+++ b/weread/lib/footnotes.lua
@@ -1,0 +1,469 @@
+--[[--
+书籍脚注处理：img 注脚、跨文件 Text/*.xhtml 链接 → EPUB3 内联脚注
+
+@module lib.footnotes
+--]]--
+
+local ok_json, JSON = pcall(require, "json")
+if not ok_json then
+    ok_json, JSON = pcall(require, "rapidjson")
+end
+
+local ok_ffiutil, ffiutil = pcall(require, "ffi/util")
+local ok_logger, logger = pcall(require, "logger")
+if not ok_logger then
+    logger = nil
+end
+
+local LOG_MODULE = "[WeRead]"
+
+local ok_util, util = pcall(require, "util")
+
+local Footnotes = {}
+
+local function log_info(...)
+    if logger then
+        logger.info(LOG_MODULE, ...)
+    end
+end
+
+Footnotes.FOOTNOTES_CSS = [[
+.fn-ref{font-size:0.75em;vertical-align:super;line-height:0;}
+.fn-ref a{position:relative;text-decoration:none;color:#0366d6;}
+.fn-ref a::after{content:"";position:absolute;top:-0.5em;right:-0.3em;bottom:-0.5em;left:-0.3em;}
+aside.footnote{margin:0.5em 0;font-size:0.85em;text-indent:0!important;text-align:left!important;}
+div.footnotes{margin-top:2em;padding-top:0.5em;border-top:1px solid #ccc;}
+.fn-num{font-weight:bold;margin-right:0.3em;text-decoration:none;color:inherit;}
+]]
+
+local function join_path(a, b)
+    if ok_ffiutil then
+        return ffiutil.joinPath(a, b)
+    end
+    return tostring(a or "") .. "/" .. tostring(b or "")
+end
+
+local function ensure_dir(path)
+    if ok_util and util.makePath then
+        util.makePath(path)
+        return
+    end
+    os.execute("mkdir -p " .. string.format("%q", path))
+end
+
+local function sort_chapters(chapters)
+    if type(chapters) ~= "table" then
+        return {}
+    end
+    local sorted = {}
+    for index, chapter in ipairs(chapters) do
+        sorted[index] = chapter
+    end
+    table.sort(sorted, function(a, b)
+        local ia = a.chapterIdx or a.chapterUid or 0
+        local ib = b.chapterIdx or b.chapterUid or 0
+        return ia < ib
+    end)
+    return sorted
+end
+
+local function xml_escape(text)
+    return (tostring(text or "")
+        :gsub("&", "&amp;")
+        :gsub("<", "&lt;")
+        :gsub(">", "&gt;")
+        :gsub('"', "&quot;"))
+end
+
+local function strip_tags(html)
+    return (tostring(html or ""):gsub("<[^>]+>", ""):gsub("%s+", " "):match("^%s*(.-)%s*$") or "")
+end
+
+local function is_trivial_footnote_text(text)
+    if type(text) ~= "string" or text == "" then
+        return true
+    end
+    return text:match("^%[%d+%]$") ~= nil
+end
+
+local function cleanup_footnote_text(text)
+    text = strip_tags(text)
+    if text == "" then return "" end
+    text = text:gsub("^%[%d+%]%s*", "")
+    text = text:gsub("^%*%s*", "")
+    return text:match("^%s*(.-)%s*$") or ""
+end
+
+local function extract_anchor_text(html, anchor)
+    if type(html) ~= "string" or type(anchor) ~= "string" or anchor == "" then
+        return nil
+    end
+
+    local escaped = anchor:gsub("([%.%-%+%[%]%(%)%$%^%%%?%*])", "%%%1")
+    local patterns = {
+        '<p[^>]-id="' .. escaped .. '"[^>]->(.-)</p>',
+        '<div[^>]-id="' .. escaped .. '"[^>]->(.-)</div>',
+        '<aside[^>]-id="' .. escaped .. '"[^>]->(.-)</aside>',
+        '<li[^>]-id="' .. escaped .. '"[^>]->(.-)</li>',
+        'id="' .. escaped .. '"[^>]->(.-)</p>',
+        'name="' .. escaped .. '"[^>]->(.-)</p>',
+    }
+
+    for _, pattern in ipairs(patterns) do
+        local block = html:match(pattern)
+        if block then
+            local text = cleanup_footnote_text(block)
+            if text ~= "" and not is_trivial_footnote_text(text) then
+                return text
+            end
+        end
+    end
+
+    return nil
+end
+
+local function anchor_cache_path(book_dir)
+    return join_path(book_dir, "footnotes/anchors.json")
+end
+
+function Footnotes.load_anchor_cache(book_dir)
+    local path = anchor_cache_path(book_dir)
+    local file = io.open(path, "r")
+    if not file then return {} end
+    local data = file:read("*a")
+    file:close()
+    if not ok_json then return {} end
+    local ok, parsed = pcall(JSON.decode, data or "")
+    if ok and type(parsed) == "table" then
+        return parsed
+    end
+    return {}
+end
+
+function Footnotes.save_anchor_cache(book_dir, cache)
+    if type(book_dir) ~= "string" or book_dir == "" then return end
+    if type(cache) ~= "table" then return end
+    if not ok_json then return end
+    ensure_dir(join_path(book_dir, "footnotes"))
+    local ok, encoded = pcall(JSON.encode, cache)
+    if not ok then return end
+    local file = io.open(anchor_cache_path(book_dir), "w")
+    if not file then return end
+    file:write(encoded)
+    file:close()
+end
+
+function Footnotes.index_anchors(html)
+    local map = {}
+    if type(html) ~= "string" or html == "" then
+        return map
+    end
+
+    local seen = {}
+    for anchor in html:gmatch('[%s]id="([^"]+)"') do
+        if not seen[anchor] then
+            seen[anchor] = true
+            local text = extract_anchor_text(html, anchor)
+            if text and text ~= "" then
+                map[anchor] = text
+            end
+        end
+    end
+
+    for anchor in html:gmatch('[%s]name="([^"]+)"') do
+        if not seen[anchor] and not map[anchor] then
+            seen[anchor] = true
+            local text = extract_anchor_text(html, anchor)
+            if text and text ~= "" then
+                map[anchor] = text
+            end
+        end
+    end
+
+    return map
+end
+
+function Footnotes.convert_img_footnotes(html)
+    if type(html) ~= "string" or html == "" then
+        return html, {}
+    end
+
+    local footnotes = {}
+    local fn_idx = 0
+
+    local result = html:gsub('<img%s+[^>]-class="qqreader%-footnote"[^>]*/?>', function(match)
+        local alt = match:match('alt="([^"]*)"') or ""
+        if alt == "" then
+            return match
+        end
+        fn_idx = fn_idx + 1
+        footnotes[fn_idx] = alt
+        return string.format(
+            '<span class="fn-ref"><a epub:type="noteref" href="#wt_%d" id="wtref_%d">[%d]</a></span>',
+            fn_idx, fn_idx, fn_idx
+        )
+    end)
+
+    return result, footnotes
+end
+
+local cross_link_re = '<a%s+href="([^"]*/Text/([^"]+%.xhtml))#([^"]+)"[^>]*>%s*<span[^>]*>%[(%d+)%]</span>%s*</a>'
+
+function Footnotes.collect_cross_file_refs(html)
+    local refs = {}
+    local seen = {}
+    if type(html) ~= "string" then
+        return refs
+    end
+
+    for full_href, file, anchor, num in html:gmatch(cross_link_re) do
+        if not seen[anchor] then
+            seen[anchor] = true
+            refs[#refs + 1] = {
+                anchor = anchor,
+                num = tonumber(num) or (#refs + 1),
+                file = file,
+                href = full_href,
+            }
+        end
+    end
+
+    table.sort(refs, function(a, b) return a.num < b.num end)
+    return refs
+end
+
+function Footnotes.fetch_missing_anchors(meta, missing, ref_files)
+    if type(missing) ~= "table" or #missing == 0 then
+        return {}
+    end
+
+    ref_files = ref_files or {}
+    local file_set = {}
+    for _, file_name in ipairs(ref_files) do
+        if type(file_name) == "string" and file_name ~= "" then
+            file_set[file_name] = true
+        end
+    end
+
+    local book_dir = meta.book_dir
+    local cache = Footnotes.load_anchor_cache(book_dir)
+    local found = {}
+    local still_missing = {}
+
+    for _, anchor in ipairs(missing) do
+        local cached = cache[anchor]
+        if cached and cached ~= "" and not is_trivial_footnote_text(cached) then
+            found[anchor] = cached
+        else
+            if cached and is_trivial_footnote_text(cached) then
+                cache[anchor] = nil
+            end
+            still_missing[#still_missing + 1] = anchor
+        end
+    end
+
+    if #still_missing == 0 then
+        return found
+    end
+
+    local chapters = meta.chapters
+    if type(chapters) ~= "table" or #chapters == 0 then
+        if type(meta.fetch_catalog) == "function" then
+            local ok, toc = pcall(meta.fetch_catalog)
+            if ok and type(toc) == "table" then
+                chapters = toc
+            end
+        end
+    end
+
+    if type(chapters) ~= "table" or #chapters == 0 then
+        return found
+    end
+
+    local fetch_chapter_html = meta.fetch_chapter_html
+    if type(fetch_chapter_html) ~= "function" then
+        return found
+    end
+
+    local sorted = sort_chapters(chapters)
+    local scanned_uids = {}
+    local max_scan = math.min(40, #sorted)
+
+    local function try_chapter(chapter, preloaded_html)
+        if not chapter or not chapter.chapterUid then return end
+        if scanned_uids[chapter.chapterUid] then return end
+        scanned_uids[chapter.chapterUid] = true
+
+        local html = preloaded_html
+        if not html then
+            local ok, fetched = pcall(fetch_chapter_html, chapter)
+            if not ok or type(fetched) ~= "string" or fetched == "" then
+                return
+            end
+            html = fetched
+        end
+
+        for _, anchor in ipairs(still_missing) do
+            if not found[anchor] then
+                local text = extract_anchor_text(html, anchor)
+                if text and text ~= "" then
+                    found[anchor] = text
+                    cache[anchor] = text
+                end
+            end
+        end
+
+        for index = #still_missing, 1, -1 do
+            if found[still_missing[index]] then
+                table.remove(still_missing, index)
+            end
+        end
+    end
+
+    if next(file_set) then
+        for _, chapter in ipairs(sorted) do
+            if #still_missing == 0 then break end
+            local ok, html = pcall(fetch_chapter_html, chapter)
+            if ok and type(html) == "string" and html ~= "" then
+                for file_name in pairs(file_set) do
+                    if html:find(file_name, 1, true) then
+                        try_chapter(chapter, html)
+                        break
+                    end
+                end
+            end
+        end
+    end
+
+    for _, chapter in ipairs(sorted) do
+        if #still_missing == 0 then break end
+        local title = (chapter.title or ""):lower()
+        if title:find("注释") or title:find("脚注") or title:find("尾注") or title:find("note") then
+            try_chapter(chapter)
+        end
+    end
+
+    local scanned = 0
+    for index = #sorted, 1, -1 do
+        if #still_missing == 0 or scanned >= max_scan then break end
+        try_chapter(sorted[index])
+        scanned = scanned + 1
+    end
+
+    if #still_missing > 0 then
+        for _, chapter in ipairs(sorted) do
+            if #still_missing == 0 then break end
+            try_chapter(chapter)
+        end
+    end
+
+    if next(cache) then
+        Footnotes.save_anchor_cache(book_dir, cache)
+    end
+
+    return found
+end
+
+function Footnotes.convert_cross_file_footnotes(html, anchor_texts, fn_offset)
+    if type(html) ~= "string" or html == "" then
+        return html, {}
+    end
+
+    anchor_texts = anchor_texts or {}
+    fn_offset = fn_offset or 0
+    local footnotes = {}
+    local fn_idx = fn_offset
+
+    local result = html:gsub(cross_link_re, function(_full_href, _file, anchor, num)
+        local text = anchor_texts[anchor]
+        if not text or text == "" or is_trivial_footnote_text(text) then
+            return string.format('<sup class="fn-ref">[%s]</sup>', num)
+        end
+        fn_idx = fn_idx + 1
+        footnotes[#footnotes + 1] = { num = num, text = text, anchor = anchor, fn_idx = fn_idx }
+        return string.format(
+            '<span class="fn-ref"><a epub:type="noteref" href="#wt_%d" id="wtref_%d">[%s]</a></span>',
+            fn_idx, fn_idx, num
+        )
+    end)
+
+    return result, footnotes
+end
+
+local function build_footnote_section(img_notes, cross_notes)
+    local total = #(img_notes or {}) + #(cross_notes or {})
+    if total == 0 then
+        return ""
+    end
+
+    local parts = { '\n<div class="footnotes">\n<hr/>\n' }
+    local idx = 0
+
+    for _, text in ipairs(img_notes or {}) do
+        idx = idx + 1
+        parts[#parts + 1] = string.format(
+            '<aside epub:type="footnote" id="wt_%d" class="footnote weread-book-footnote"><p><a href="#wtref_%d" class="fn-num">[%d]</a> %s</p></aside>\n',
+            idx, idx, idx, xml_escape(text)
+        )
+    end
+
+    for _, note in ipairs(cross_notes or {}) do
+        local note_idx = note.fn_idx
+        parts[#parts + 1] = string.format(
+            '<aside epub:type="footnote" id="wt_%d" class="footnote weread-book-footnote"><p><a href="#wtref_%d" class="fn-num">[%s]</a> %s</p></aside>\n',
+            note_idx, note_idx, note.num, xml_escape(note.text)
+        )
+    end
+
+    parts[#parts + 1] = "</div>\n"
+    return table.concat(parts)
+end
+
+function Footnotes.process(html, meta)
+    if type(html) ~= "string" or html == "" then
+        return html, ""
+    end
+    if meta and meta.is_txt then
+        return html, ""
+    end
+
+    local local_index = Footnotes.index_anchors(html)
+    local refs = Footnotes.collect_cross_file_refs(html)
+    if #refs == 0 then
+        local converted, img_notes = Footnotes.convert_img_footnotes(html)
+        local section = build_footnote_section(img_notes, {})
+        return converted, section
+    end
+
+    local missing = {}
+    local ref_files = {}
+    local file_seen = {}
+    for _, ref in ipairs(refs) do
+        if not local_index[ref.anchor] then
+            missing[#missing + 1] = ref.anchor
+        end
+        if ref.file and not file_seen[ref.file] then
+            file_seen[ref.file] = true
+            ref_files[#ref_files + 1] = ref.file
+        end
+    end
+
+    local remote = Footnotes.fetch_missing_anchors(meta, missing, ref_files)
+    local anchor_texts = {}
+    for _, ref in ipairs(refs) do
+        anchor_texts[ref.anchor] = local_index[ref.anchor] or remote[ref.anchor]
+    end
+
+    local html1, img_notes = Footnotes.convert_img_footnotes(html)
+    local html2, cross_notes = Footnotes.convert_cross_file_footnotes(html1, anchor_texts, #img_notes)
+    local section = build_footnote_section(img_notes, cross_notes)
+
+    if section ~= "" then
+        log_info("footnotes converted:", #img_notes + #cross_notes, "notes")
+    elseif #refs > 0 then
+        log_info("footnotes refs found but content missing:", #refs)
+    end
+    return html2, section
+end
+
+return Footnotes

--- a/weread/lib/footnotes.lua
+++ b/weread/lib/footnotes.lua
@@ -6,26 +6,19 @@
 
 local ok_json, JSON = pcall(require, "json")
 if not ok_json then
-    ok_json, JSON = pcall(require, "rapidjson")
+    JSON = require("rapidjson")
 end
 
-local ok_ffiutil, ffiutil = pcall(require, "ffi/util")
+local ffiutil = require("ffi/util")
 local ok_logger, logger = pcall(require, "logger")
 if not ok_logger then
     logger = nil
 end
 
 local LOG_MODULE = "[WeRead]"
-
-local ok_util, util = pcall(require, "util")
+local util = require("util")
 
 local Footnotes = {}
-
-local function log_info(...)
-    if logger then
-        logger.info(LOG_MODULE, ...)
-    end
-end
 
 Footnotes.FOOTNOTES_CSS = [[
 .fn-ref{font-size:0.75em;vertical-align:super;line-height:0;}
@@ -37,18 +30,11 @@ div.footnotes{margin-top:2em;padding-top:0.5em;border-top:1px solid #ccc;}
 ]]
 
 local function join_path(a, b)
-    if ok_ffiutil then
-        return ffiutil.joinPath(a, b)
-    end
-    return tostring(a or "") .. "/" .. tostring(b or "")
+    return ffiutil.joinPath(a, b)
 end
 
 local function ensure_dir(path)
-    if ok_util and util.makePath then
-        util.makePath(path)
-        return
-    end
-    os.execute("mkdir -p " .. string.format("%q", path))
+    util.makePath(path)
 end
 
 local function sort_chapters(chapters)
@@ -132,7 +118,6 @@ function Footnotes.load_anchor_cache(book_dir)
     if not file then return {} end
     local data = file:read("*a")
     file:close()
-    if not ok_json then return {} end
     local ok, parsed = pcall(JSON.decode, data or "")
     if ok and type(parsed) == "table" then
         return parsed
@@ -143,7 +128,6 @@ end
 function Footnotes.save_anchor_cache(book_dir, cache)
     if type(book_dir) ~= "string" or book_dir == "" then return end
     if type(cache) ~= "table" then return end
-    if not ok_json then return end
     ensure_dir(join_path(book_dir, "footnotes"))
     local ok, encoded = pcall(JSON.encode, cache)
     if not ok then return end
@@ -459,9 +443,9 @@ function Footnotes.process(html, meta)
     local section = build_footnote_section(img_notes, cross_notes)
 
     if section ~= "" then
-        log_info("footnotes converted:", #img_notes + #cross_notes, "notes")
+        if logger then logger.info(LOG_MODULE, "footnotes converted:", #img_notes + #cross_notes, "notes") end
     elseif #refs > 0 then
-        log_info("footnotes refs found but content missing:", #refs)
+        if logger then logger.info(LOG_MODULE, "footnotes refs found but content missing:", #refs) end
     end
     return html2, section
 end

--- a/weread/lib/footnotes.lua
+++ b/weread/lib/footnotes.lua
@@ -29,6 +29,27 @@ div.footnotes{margin-top:2em;padding-top:0.5em;border-top:1px solid #ccc;}
 .fn-num{font-weight:bold;margin-right:0.3em;text-decoration:none;color:inherit;}
 ]]
 
+local TEXT_FOOTNOTE_LINK_SCAN_RE = '<a%s+[^>]-href="[^"]*/Text/[^"]+%.[x]?html#[^"]+"[^>]*>.-</a>'
+local LOCAL_HASH_LINK_SCAN_RE = '<a%s+[^>]-href="#[^"]+"[^>]*>.-</a>'
+local FOOTNOTE_BLOCK_PATTERNS = {
+    '<p[^>]-class="fnContent[^"]*"[^>]->.-</p>',
+    '<p[^>]-class="note"[^>]->.-</p>',
+}
+
+local BLOCK_PLACEHOLDER_PREFIX = "\029BLOCK"
+local BLOCK_PLACEHOLDER_SUFFIX = "\029"
+
+local SECTION_CN = {
+    "一", "二", "三", "四", "五", "六", "七", "八", "九", "十",
+    "十一", "十二", "十三", "十四", "十五", "十六", "十七", "十八", "十九", "二十",
+}
+
+local function log_info(...)
+    if logger then
+        logger.info(LOG_MODULE, ...)
+    end
+end
+
 local function join_path(a, b)
     return ffiutil.joinPath(a, b)
 end
@@ -53,6 +74,18 @@ local function sort_chapters(chapters)
     return sorted
 end
 
+local function find_chapter_by_idx(chapters, idx)
+    if type(chapters) ~= "table" or not idx then
+        return nil
+    end
+    for _, chapter in ipairs(chapters) do
+        if chapter.chapterIdx == idx then
+            return chapter
+        end
+    end
+    return nil
+end
+
 local function xml_escape(text)
     return (tostring(text or "")
         :gsub("&", "&amp;")
@@ -65,19 +98,331 @@ local function strip_tags(html)
     return (tostring(html or ""):gsub("<[^>]+>", ""):gsub("%s+", " "):match("^%s*(.-)%s*$") or "")
 end
 
+local function escape_pattern(text)
+    return tostring(text or ""):gsub("([%.%-%+%[%]%(%)%$%^%%%?%*])", "%%%1")
+end
+
+local function utf8_char_len(str, pos)
+    local b = str:byte(pos)
+    if not b then return 1 end
+    if b < 0x80 then return 1 end
+    if b < 0xE0 then return 2 end
+    if b < 0xF0 then return 3 end
+    return 4
+end
+
+--- 字节位置 → 1-based rune 索引（与 annotations.toRunes 一致）。
+local function byte_to_rune_index(str, byte_pos)
+    local rune_idx = 0
+    local i = 1
+    while i < byte_pos and i <= #str do
+        rune_idx = rune_idx + 1
+        i = i + utf8_char_len(str, i)
+    end
+    return rune_idx + 1
+end
+
+local function byte_range_to_rune_range(str, bstart, bend)
+    return byte_to_rune_index(str, bstart), byte_to_rune_index(str, bend + 1)
+end
+
 local function is_trivial_footnote_text(text)
     if type(text) ~= "string" or text == "" then
         return true
     end
-    return text:match("^%[%d+%]$") ~= nil
+    return text:match("^%[%d+%]$") ~= nil or text:match("^%(%d+%)$") ~= nil
 end
 
 local function cleanup_footnote_text(text)
     text = strip_tags(text)
     if text == "" then return "" end
     text = text:gsub("^%[%d+%]%s*", "")
+    text = text:gsub("^%(%d+%)%s*", "")
     text = text:gsub("^%*%s*", "")
     return text:match("^%s*(.-)%s*$") or ""
+end
+
+local function extract_footnote_num(inner)
+    if type(inner) ~= "string" then return nil end
+    local text = strip_tags(inner)
+    if text == "" then return nil end
+    return text:match("^%[(%d+)%]$")
+        or text:match("%[(%d+)%]")
+        or text:match("^%((%d+)%)$")
+        or text:match("%((%d+)%)")
+end
+
+local function link_inner_html(link)
+    return (tostring(link or ""):match("<a[^>]*>(.-)</a>") or "")
+end
+
+local function href_fragment(href)
+    if type(href) ~= "string" then return nil end
+    return href:match("#([^#]+)$")
+end
+
+local function is_cross_text_href(href)
+    return type(href) == "string" and href:find('/Text/[^"]+%.[x]?html#', 1, false) ~= nil
+end
+
+local function num_from_link_context(link)
+    if type(link) ~= "string" then return nil end
+    local id = link:match('id="([^"]+)"')
+    local fragment = href_fragment(link:match('href="([^"]+)"') or "")
+    for _, token in ipairs({ id, fragment }) do
+        if token then
+            local num = token:match("_(%d+)_")
+                or token:match("^(%d+)$")
+                or token:match("_(%d+)$")
+                or token:match("(%d+)$")
+            if num then return num end
+        end
+    end
+    return nil
+end
+
+local function footnote_num_from_link(link)
+    if type(link) ~= "string" then return nil end
+    return extract_footnote_num(link_inner_html(link)) or num_from_link_context(link)
+end
+
+local function each_footnote_block(html, fn)
+    if type(html) ~= "string" then return end
+    for _, pattern in ipairs(FOOTNOTE_BLOCK_PATTERNS) do
+        for block in html:gmatch(pattern) do
+            fn(block)
+        end
+    end
+end
+
+local function parse_footnote_reference_link(link)
+    if type(link) ~= "string" then return nil end
+    local href = link:match('href="([^"]+)"')
+    if not href then return nil end
+    local num = footnote_num_from_link(link)
+    if not num then return nil end
+
+    local fragment = href_fragment(href)
+    if not fragment then return nil end
+
+    if is_cross_text_href(href) then
+        local full_href, file = href:match('^(.*/Text/([^"]+%.[x]?html))#')
+        if not full_href or not file then return nil end
+        return { anchor = fragment, num = num, file = file, href = full_href .. "#" .. fragment }
+    end
+
+    if href:match("^#") then
+        return { anchor = fragment, num = num, href = href }
+    end
+
+    return nil
+end
+
+local function is_publisher_footnote_link(link)
+    if type(link) ~= "string" then return false end
+    if link:find('epub:type="noteref"', 1, false) or link:find('href="#wt_', 1, false) then
+        return false
+    end
+    return parse_footnote_reference_link(link) ~= nil
+end
+
+local function parse_footnote_definition_link(link)
+    if type(link) ~= "string" then return nil end
+    local id = link:match('id="([^"]+)"')
+    if not id then return nil end
+    local num = footnote_num_from_link(link)
+    if not num then return nil end
+
+    local href = link:match('href="([^"]+)"')
+    local file
+    if href and is_cross_text_href(href) then
+        local _, ref_file = href:match('^(.*/Text/([^"]+%.[x]?html))#')
+        file = ref_file
+    end
+
+    return {
+        anchor = id,
+        num = num,
+        file = file,
+        href = href or ("#" .. id),
+    }
+end
+
+local function discover_reciprocal_anchors(html)
+    local reciprocal = {}
+    if type(html) ~= "string" or html == "" then
+        return reciprocal
+    end
+
+    local by_id = {}
+    for link in html:gmatch("<a%s+[^>]*>.-</a>") do
+        local id = link:match('id="([^"]+)"')
+        local target = href_fragment(link:match('href="([^"]+)"') or "")
+        if id and target then
+            by_id[id] = target
+        end
+    end
+    for id, target in pairs(by_id) do
+        if by_id[target] == id then
+            reciprocal[id] = target
+            reciprocal[target] = id
+        end
+    end
+
+    each_footnote_block(html, function(block)
+        local marker_id = block:match('<a[^>]-id="([^"]+)"[^>]*>%s*</a>')
+        local back_link = block:match('<a[^>]-href="[^"]-#[^"]+"[^>]*>.-</a>')
+        local back_target = back_link and href_fragment(back_link:match('href="([^"]+)"') or "")
+        if marker_id and back_target and footnote_num_from_link(back_link) then
+            reciprocal[marker_id] = back_target
+            reciprocal[back_target] = marker_id
+        end
+    end)
+
+    return reciprocal
+end
+
+local function is_disposable_marker_anchor(html, anchor)
+    if type(html) ~= "string" or type(anchor) ~= "string" or anchor == "" then
+        return false
+    end
+    local esc = escape_pattern(anchor)
+    if not html:find('<a[^>]-id="' .. esc .. '"[^>]*>%s*</a>', 1, false) then
+        return false
+    end
+    local in_footnote_block = false
+    each_footnote_block(html, function(block)
+        if block:find('id="' .. esc .. '"', 1, false) then
+            in_footnote_block = true
+        end
+    end)
+    if in_footnote_block then return false end
+    return true
+end
+
+local function strip_empty_marker_anchors(html)
+    if type(html) ~= "string" then return html end
+    return html:gsub(
+        '<a%s+id="([^"]+)"[^>]*>%s*</a>%s*(<a%s+[^>]-href="[^"]*/Text/[^"]+%.[x]?html#[^"]+"[^>]*>.-</a>)',
+        function(_marker_id, ref_link)
+            if parse_footnote_reference_link(ref_link) then
+                return ref_link
+            end
+            return nil
+        end
+    )
+end
+
+local function merge_footnote_spans(spans)
+    if #spans == 0 then return spans end
+    table.sort(spans, function(a, b) return a.start < b.start end)
+    local merged = { spans[1] }
+    for i = 2, #spans do
+        local cur = spans[i]
+        local last = merged[#merged]
+        if cur.start <= last.end_pos then
+            if cur.end_pos > last.end_pos then
+                last.end_pos = cur.end_pos
+            end
+        else
+            merged[#merged + 1] = cur
+        end
+    end
+    return merged
+end
+
+local function append_link_spans(html, spans, scan_re, predicate)
+    local pos = 1
+    while true do
+        local bstart, bend = html:find(scan_re, pos)
+        if not bstart then break end
+        local link = html:sub(bstart, bend)
+        if not predicate or predicate(link) then
+            local rs, re_ex = byte_range_to_rune_range(html, bstart, bend)
+            spans[#spans + 1] = { start = rs, end_pos = re_ex }
+        end
+        pos = bend + 1
+    end
+end
+
+local function replace_sup_paren_with_span_bracket(html)
+    return html:gsub("<sup>%((%d+)%)%</sup>", "<span>[%1]</span>")
+end
+
+local function normalize_footnote_link_tag(a_tag)
+    if type(a_tag) ~= "string" then return a_tag end
+
+    if a_tag:find("reader_footer_note", 1, true) then
+        local num = footnote_num_from_link(a_tag) or "1"
+        local open = a_tag:match("^(<a%s+[^>]*>)")
+        if open then
+            return open .. "<span>[" .. num .. "]</span></a>"
+        end
+    end
+
+    if a_tag:find("<sup", 1, true) and a_tag:find("%(%d+%)", 1, false) then
+        local num = a_tag:match("<span[^>]*>%((%d+)%)</span>")
+            or a_tag:match("<sup[^>]*>%((%d+)%)</sup>")
+        if num then
+            local open = a_tag:match("^(<a%s+[^>]*>)")
+            if open then
+                return open .. "<span>[" .. num .. "]</span></a>"
+            end
+        end
+        return replace_sup_paren_with_span_bracket(a_tag)
+    end
+
+    return a_tag
+end
+
+--- 将脚注 markup 中的 (N) 统一为 [N]（不触碰正文普通括号）。
+function Footnotes.normalize_markup(html)
+    if type(html) ~= "string" or html == "" then
+        return html
+    end
+
+    html = html:gsub("(<p[^>]-class=\"fnContent[^\"]*\"[^>]->.-)(</p>)", function(block, close)
+        block = block:gsub("<span[^>]*>%((%d+)%)</span></a>", "<span>[%1]</span></a>")
+        block = block:gsub(">%((%d+)%)</a>", ">[%1]</a>")
+        return block .. close
+    end)
+
+    local function maybe_normalize_footnote_link(link)
+        if parse_footnote_reference_link(link) or link:find("reader_footer_note", 1, true) then
+            return normalize_footnote_link_tag(link)
+        end
+        return link
+    end
+
+    html = html:gsub(TEXT_FOOTNOTE_LINK_SCAN_RE, maybe_normalize_footnote_link)
+    html = html:gsub(LOCAL_HASH_LINK_SCAN_RE, maybe_normalize_footnote_link)
+
+    return html
+end
+
+--- 返回脚注保护区 rune 区间（end_pos 为开区间，与 annotations range 一致）。
+function Footnotes.find_footnote_spans(html)
+    if type(html) ~= "string" or html == "" then
+        return {}
+    end
+
+    local spans = {}
+    append_link_spans(html, spans, TEXT_FOOTNOTE_LINK_SCAN_RE, function(link)
+        return is_publisher_footnote_link(link)
+    end)
+    append_link_spans(html, spans, LOCAL_HASH_LINK_SCAN_RE, function(link)
+        return is_publisher_footnote_link(link)
+    end)
+
+    local static_patterns = {
+        '<p[^>]-class="fnContent[^"]*"[^>]->.-</a>',
+        '<p[^>]-class="note"[^>]->.-</p>',
+    }
+    for _, pattern in ipairs(static_patterns) do
+        append_link_spans(html, spans, pattern)
+    end
+
+    return merge_footnote_spans(spans)
 end
 
 local function extract_anchor_text(html, anchor)
@@ -85,9 +430,12 @@ local function extract_anchor_text(html, anchor)
         return nil
     end
 
-    local escaped = anchor:gsub("([%.%-%+%[%]%(%)%$%^%%%?%*])", "%%%1")
+    local escaped = escape_pattern(anchor)
     local patterns = {
+        '<p[^>]-class="note"[^>]->.-id="' .. escaped .. '"[^>]->(.-)</p>',
+        '<p[^>]-class="fnContent[^"]*"[^>]->.-id="' .. escaped .. '"[^>]->(.-)</p>',
         '<p[^>]-id="' .. escaped .. '"[^>]->(.-)</p>',
+        '<p[^>]-class="fnContent[^"]*"[^>]->.-#' .. escaped .. '"[^>]->(.-)</p>',
         '<div[^>]-id="' .. escaped .. '"[^>]->(.-)</div>',
         '<aside[^>]-id="' .. escaped .. '"[^>]->(.-)</aside>',
         '<li[^>]-id="' .. escaped .. '"[^>]->(.-)</li>',
@@ -108,11 +456,90 @@ local function extract_anchor_text(html, anchor)
     return nil
 end
 
+local function extract_fn_content_block(html, anchor)
+    if type(html) ~= "string" or type(anchor) ~= "string" or anchor == "" then
+        return nil
+    end
+
+    for block in html:gmatch('<p[^>]-class="fnContent[^"]*"[^>]->.-</p>') do
+        if block:find('id="' .. anchor .. '"', 1, true)
+            or block:find("#" .. anchor, 1, true) then
+            return block
+        end
+    end
+
+    return nil
+end
+
+local function extract_fn_content_body(html, anchor)
+    local block = extract_fn_content_block(html, anchor)
+    if not block then return nil end
+
+    local body = block
+    body = body:gsub("^%s*<p[^>]*>%s*", "")
+    body = body:gsub("%s*</p>%s*$", "")
+
+    body = body:gsub("^%s*<a[^>]->%s*<span[^>]*>%[%d+%]%</span>%s*</a>%s*", "")
+    body = body:gsub("^%s*<a[^>]->%s*%[%d+%]%s*</a>%s*", "")
+    body = body:gsub("^%s*<a[^>]->%s*<span[^>]*>%(%d+)%)</span>%s*</a>%s*", "")
+    body = body:gsub("^%s*<a[^>]->%s*%(%d+%)%s*</a>%s*", "")
+
+    local stripped = false
+    body = body:gsub("^(%s*<a[^>]->.-</a>%s*)", function(prefix)
+        if stripped then return prefix end
+        local label = strip_tags(prefix)
+        if label:match("^%[%d+%]$") or label:match("^%(%d+%)$") then
+            stripped = true
+            return ""
+        end
+        return prefix
+    end)
+
+    if body:match("^%s*$") then
+        return nil
+    end
+    return body
+end
+
+local function extract_note_block(html, anchor)
+    if type(html) ~= "string" or type(anchor) ~= "string" or anchor == "" then
+        return nil
+    end
+
+    for block in html:gmatch('<p[^>]-class="note"[^>]->.-</p>') do
+        if block:find('id="' .. anchor .. '"', 1, true) then
+            return block
+        end
+    end
+
+    return nil
+end
+
+local function extract_note_body(html, anchor)
+    local block = extract_note_block(html, anchor)
+    if not block then return nil end
+
+    local body = block
+    body = body:gsub("^%s*<p[^>]*>%s*", "")
+    body = body:gsub("%s*</p>%s*$", "")
+    body = body:gsub("^%s*<a[^>]->%s*</a>%s*", "")
+    body = body:gsub("^%s*<a[^>]->%s*<span[^>]*>%[%d+%]%</span>%s*</a>%s*", "")
+    body = body:gsub("^%s*<a[^>]->%s*%[%d+%]%s*</a>%s*", "")
+
+    if body:match("^%s*$") then
+        return nil
+    end
+    return body
+end
+
 local function anchor_cache_path(book_dir)
     return join_path(book_dir, "footnotes/anchors.json")
 end
 
 function Footnotes.load_anchor_cache(book_dir)
+    if type(book_dir) ~= "string" or book_dir == "" then
+        return {}
+    end
     local path = anchor_cache_path(book_dir)
     local file = io.open(path, "r")
     if not file then return {} end
@@ -145,7 +572,7 @@ function Footnotes.index_anchors(html)
 
     local seen = {}
     for anchor in html:gmatch('[%s]id="([^"]+)"') do
-        if not seen[anchor] then
+        if not seen[anchor] and not is_disposable_marker_anchor(html, anchor) then
             seen[anchor] = true
             local text = extract_anchor_text(html, anchor)
             if text and text ~= "" then
@@ -155,7 +582,7 @@ function Footnotes.index_anchors(html)
     end
 
     for anchor in html:gmatch('[%s]name="([^"]+)"') do
-        if not seen[anchor] and not map[anchor] then
+        if not seen[anchor] and not map[anchor] and not is_disposable_marker_anchor(html, anchor) then
             seen[anchor] = true
             local text = extract_anchor_text(html, anchor)
             if text and text ~= "" then
@@ -191,44 +618,171 @@ function Footnotes.convert_img_footnotes(html)
     return result, footnotes
 end
 
-local cross_link_re = '<a%s+href="([^"]*/Text/([^"]+%.xhtml))#([^"]+)"[^>]*>%s*<span[^>]*>%[(%d+)%]</span>%s*</a>'
+local function mask_protected_blocks(html)
+    local blocks = {}
+    local function mask_pattern(pattern)
+        html = html:gsub(pattern, function(block)
+            blocks[#blocks + 1] = block
+            return BLOCK_PLACEHOLDER_PREFIX .. tostring(#blocks) .. BLOCK_PLACEHOLDER_SUFFIX
+        end)
+    end
+    mask_pattern("(<p[^>]-class=\"fnContent[^\"]*\"[^>]->.-</p>)")
+    mask_pattern("(<p[^>]-class=\"note\"[^>]->.-</p>)")
+    return html, blocks
+end
 
-function Footnotes.collect_cross_file_refs(html)
+local function unmask_protected_blocks(html, blocks)
+    return html:gsub(
+        BLOCK_PLACEHOLDER_PREFIX .. "(%d+)" .. BLOCK_PLACEHOLDER_SUFFIX,
+        function(i)
+            return blocks[tonumber(i)] or ""
+        end
+    )
+end
+
+local function add_footnote_ref(refs, seen, anchor, num, file, full_href)
+    if seen[anchor] then return end
+    seen[anchor] = true
+    refs[#refs + 1] = {
+        anchor = anchor,
+        num = tonumber(num) or (#refs + 1),
+        file = file,
+        href = full_href,
+    }
+end
+
+local function collect_fn_content_footnote_refs(html, refs, seen)
+    if type(html) ~= "string" then return end
+    for block in html:gmatch('<p[^>]-class="fnContent[^"]*"[^>]->.-</p>') do
+        for link in block:gmatch("<a%s+[^>]*>.-</a>") do
+            local parsed = parse_footnote_definition_link(link)
+            if parsed then
+                add_footnote_ref(refs, seen, parsed.anchor, parsed.num, parsed.file, parsed.href)
+            end
+        end
+    end
+end
+
+function Footnotes.collect_footnote_refs(html)
     local refs = {}
     local seen = {}
     if type(html) ~= "string" then
         return refs
     end
 
-    for full_href, file, anchor, num in html:gmatch(cross_link_re) do
-        if not seen[anchor] then
-            seen[anchor] = true
-            refs[#refs + 1] = {
-                anchor = anchor,
-                num = tonumber(num) or (#refs + 1),
-                file = file,
-                href = full_href,
-            }
+    local masked = mask_protected_blocks(html)
+
+    for link in masked:gmatch(TEXT_FOOTNOTE_LINK_SCAN_RE) do
+        local parsed = parse_footnote_reference_link(link)
+        if parsed then
+            add_footnote_ref(refs, seen, parsed.anchor, parsed.num, parsed.file, parsed.href)
         end
     end
+
+    for link in masked:gmatch(LOCAL_HASH_LINK_SCAN_RE) do
+        local parsed = is_publisher_footnote_link(link) and parse_footnote_reference_link(link)
+        if parsed then
+            add_footnote_ref(refs, seen, parsed.anchor, parsed.num, nil, parsed.href)
+        end
+    end
+
+    collect_fn_content_footnote_refs(html, refs, seen)
 
     table.sort(refs, function(a, b) return a.num < b.num end)
     return refs
 end
 
-function Footnotes.fetch_missing_anchors(meta, missing, ref_files)
+local function normalize_ref_basename(ref_file)
+    if type(ref_file) ~= "string" or ref_file == "" then return nil end
+    return ref_file:match("([^/]+%.[x]?html)$")
+end
+
+local function build_file_chapter_index(chapters)
+    local index = {}
+    if type(chapters) ~= "table" then return index end
+    for _, chapter in ipairs(chapters) do
+        local idx = chapter.chapterIdx
+        if idx then
+            local files = chapter.files
+            if type(files) == "table" then
+                for _, file in ipairs(files) do
+                    if type(file) == "string" and file ~= "" then
+                        index[file] = idx
+                        local base = file:match("([^/]+%.xhtml)$")
+                        if base then index[base] = idx end
+                    end
+                end
+            end
+        end
+    end
+    return index
+end
+
+local function find_section_start_idx(major, chapters, file_index)
+    local section_file = string.format("chapter%d.xhtml", major)
+    if file_index then
+        for file, idx in pairs(file_index) do
+            if file:match(section_file .. "$") or file:find("/" .. section_file, 1, true) then
+                return idx
+            end
+        end
+    end
+    if type(chapters) ~= "table" then return nil end
+    for _, chapter in ipairs(chapters) do
+        if chapter.level == 1 or chapter.level == nil then
+            local files = chapter.files
+            if type(files) == "table" then
+                for _, file in ipairs(files) do
+                    if file:find(section_file, 1, true) then
+                        return chapter.chapterIdx
+                    end
+                end
+            end
+        end
+    end
+    local cn = SECTION_CN[major]
+    if cn then
+        for _, chapter in ipairs(chapters) do
+            local title = chapter.title or ""
+            if title:find("第" .. cn .. "章", 1, true) then
+                return chapter.chapterIdx
+            end
+        end
+    end
+    return nil
+end
+
+local function resolve_chapter_idx_for_ref_file(ref_file, chapters, file_index)
+    local base = normalize_ref_basename(ref_file)
+    if not base then return nil end
+    if file_index and file_index[base] then
+        return file_index[base]
+    end
+    if file_index then
+        for file, idx in pairs(file_index) do
+            if file:sub(-#base) == base then
+                return idx
+            end
+        end
+    end
+    local major, minor = base:match("^chapter(%d+)_(%d+)%.xhtml$")
+    if major and minor then
+        major = tonumber(major)
+        minor = tonumber(minor)
+        local start_idx = find_section_start_idx(major, chapters, file_index)
+        if start_idx then
+            return start_idx + minor
+        end
+    end
+    return nil
+end
+
+function Footnotes.fetch_missing_anchors(meta, missing, ref_by_anchor)
     if type(missing) ~= "table" or #missing == 0 then
         return {}
     end
 
-    ref_files = ref_files or {}
-    local file_set = {}
-    for _, file_name in ipairs(ref_files) do
-        if type(file_name) == "string" and file_name ~= "" then
-            file_set[file_name] = true
-        end
-    end
-
+    ref_by_anchor = ref_by_anchor or {}
     local book_dir = meta.book_dir
     local cache = Footnotes.load_anchor_cache(book_dir)
     local found = {}
@@ -270,8 +824,38 @@ function Footnotes.fetch_missing_anchors(meta, missing, ref_files)
     end
 
     local sorted = sort_chapters(chapters)
+    local file_index = build_file_chapter_index(sorted)
     local scanned_uids = {}
     local max_scan = math.min(40, #sorted)
+    local target_idx_set = {}
+
+    for _, anchor in ipairs(still_missing) do
+        local ref_file = ref_by_anchor[anchor]
+        if ref_file then
+            local idx = resolve_chapter_idx_for_ref_file(ref_file, sorted, file_index)
+            if idx then
+                target_idx_set[idx] = true
+            end
+        end
+    end
+
+    local function try_resolve_from_html(chapter_html)
+        if not chapter_html then return end
+        for _, anchor in ipairs(still_missing) do
+            if not found[anchor] then
+                local text = extract_anchor_text(chapter_html, anchor)
+                if text and text ~= "" then
+                    found[anchor] = text
+                    cache[anchor] = text
+                end
+            end
+        end
+        for index = #still_missing, 1, -1 do
+            if found[still_missing[index]] then
+                table.remove(still_missing, index)
+            end
+        end
+    end
 
     local function try_chapter(chapter, preloaded_html)
         if not chapter or not chapter.chapterUid then return end
@@ -286,24 +870,24 @@ function Footnotes.fetch_missing_anchors(meta, missing, ref_files)
             end
             html = fetched
         end
+        try_resolve_from_html(html)
+    end
 
-        for _, anchor in ipairs(still_missing) do
-            if not found[anchor] then
-                local text = extract_anchor_text(html, anchor)
-                if text and text ~= "" then
-                    found[anchor] = text
-                    cache[anchor] = text
-                end
-            end
-        end
-
-        for index = #still_missing, 1, -1 do
-            if found[still_missing[index]] then
-                table.remove(still_missing, index)
-            end
+    for idx, _ in pairs(target_idx_set) do
+        if #still_missing == 0 then break end
+        local chapter = find_chapter_by_idx(sorted, idx)
+        if chapter then
+            try_chapter(chapter)
         end
     end
 
+    local file_set = {}
+    for _, anchor in ipairs(still_missing) do
+        local ref_file = ref_by_anchor[anchor]
+        if ref_file then
+            file_set[ref_file] = true
+        end
+    end
     if next(file_set) then
         for _, chapter in ipairs(sorted) do
             if #still_missing == 0 then break end
@@ -345,10 +929,14 @@ function Footnotes.fetch_missing_anchors(meta, missing, ref_files)
         Footnotes.save_anchor_cache(book_dir, cache)
     end
 
+    if #still_missing > 0 then
+        log_info("footnotes unresolved anchors:", #still_missing, table.concat(still_missing, ", "))
+    end
+
     return found
 end
 
-function Footnotes.convert_cross_file_footnotes(html, anchor_texts, fn_offset)
+function Footnotes.convert_footnote_refs(html, anchor_texts, fn_offset)
     if type(html) ~= "string" or html == "" then
         return html, {}
     end
@@ -358,23 +946,86 @@ function Footnotes.convert_cross_file_footnotes(html, anchor_texts, fn_offset)
     local footnotes = {}
     local fn_idx = fn_offset
 
-    local result = html:gsub(cross_link_re, function(_full_href, _file, anchor, num)
+    local function replace_footnote_link(anchor, num)
         local text = anchor_texts[anchor]
+        local num_label = "[" .. num .. "]"
         if not text or text == "" or is_trivial_footnote_text(text) then
-            return string.format('<sup class="fn-ref">[%s]</sup>', num)
+            return string.format('<sup class="fn-ref">%s</sup>', num_label)
         end
         fn_idx = fn_idx + 1
-        footnotes[#footnotes + 1] = { num = num, text = text, anchor = anchor, fn_idx = fn_idx }
+        footnotes[#footnotes + 1] = {
+            num = num_label,
+            text = text,
+            anchor = anchor,
+            fn_idx = fn_idx,
+        }
         return string.format(
-            '<span class="fn-ref"><a epub:type="noteref" href="#wt_%d" id="wtref_%d">[%s]</a></span>',
-            fn_idx, fn_idx, num
+            '<span class="fn-ref"><a epub:type="noteref" href="#wt_%d" id="wtref_%d">%s</a></span>',
+            fn_idx, fn_idx, num_label
         )
+    end
+
+    local masked, protected_blocks = mask_protected_blocks(html)
+    masked = strip_empty_marker_anchors(masked)
+    local result = masked:gsub(TEXT_FOOTNOTE_LINK_SCAN_RE, function(link)
+        local parsed = parse_footnote_reference_link(link)
+        if not parsed then return link end
+        return replace_footnote_link(parsed.anchor, parsed.num)
     end)
+    result = result:gsub(LOCAL_HASH_LINK_SCAN_RE, function(link)
+        if link:find('epub:type="noteref"', 1, false) or link:find('href="#wt_', 1, false) then return link end
+        local parsed = parse_footnote_reference_link(link)
+        if not parsed then return link end
+        return replace_footnote_link(parsed.anchor, parsed.num)
+    end)
+    result = unmask_protected_blocks(result, protected_blocks)
 
     return result, footnotes
 end
 
-local function build_footnote_section(img_notes, cross_notes)
+function Footnotes.strip_consumed_footnote_blocks(html, cross_notes)
+    if type(html) ~= "string" or html == "" then
+        return html
+    end
+    if type(cross_notes) ~= "table" or #cross_notes == 0 then
+        return html
+    end
+
+    local anchors = {}
+    local reciprocal_map = discover_reciprocal_anchors(html)
+    for _, note in ipairs(cross_notes) do
+        if note.anchor then
+            anchors[note.anchor] = true
+            local reciprocal = reciprocal_map[note.anchor]
+            if reciprocal then
+                anchors[reciprocal] = true
+            end
+        end
+    end
+
+    local function strip_fn_content_for_anchor(body, anchor)
+        local esc = escape_pattern(anchor)
+        body = body:gsub("<hr%s*/>%s*<p[^>]-class=\"fnContent[^\"]*\"[^>]->.-id=\"" .. esc .. "\".-</p>%s*", "")
+        body = body:gsub("<p[^>]-class=\"fnContent[^\"]*\"[^>]->.-id=\"" .. esc .. "\".-</p>%s*", "")
+        body = body:gsub("<hr%s*/>%s*<p[^>]-class=\"fnContent[^\"]*\"[^>]->.-#" .. esc .. "\".-</p>%s*", "")
+        body = body:gsub("<p[^>]-class=\"fnContent[^\"]*\"[^>]->.-#" .. esc .. "\".-</p>%s*", "")
+        body = body:gsub("<p[^>]-class=\"note\"[^>]->.-id=\"" .. esc .. "\".-</p>%s*", "")
+        body = body:gsub("<p[^>]-class=\"note\"[^>]->.-#" .. esc .. "\".-</p>%s*", "")
+        return body
+    end
+
+    for anchor in pairs(anchors) do
+        html = strip_fn_content_for_anchor(html, anchor)
+    end
+
+    html = html:gsub("<hr%s*/>%s*(<section[^>]-epub:type=\"footnotes\")", "%1")
+    html = html:gsub("<hr%s*/>%s*(<div%s+class=\"footnotes\")", "%1")
+    html = html:gsub("<hr%s*/>%s*(</body>)", "%1")
+
+    return html
+end
+
+local function build_footnote_section(html, img_notes, cross_notes)
     local total = #(img_notes or {}) + #(cross_notes or {})
     if total == 0 then
         return ""
@@ -393,9 +1044,14 @@ local function build_footnote_section(img_notes, cross_notes)
 
     for _, note in ipairs(cross_notes or {}) do
         local note_idx = note.fn_idx
+        local body_html = extract_fn_content_body(html, note.anchor)
+            or extract_note_body(html, note.anchor)
+        if not body_html or body_html == "" then
+            body_html = xml_escape(note.text or "")
+        end
         parts[#parts + 1] = string.format(
-            '<aside epub:type="footnote" id="wt_%d" class="footnote weread-book-footnote"><p><a href="#wtref_%d" class="fn-num">[%s]</a> %s</p></aside>\n',
-            note_idx, note_idx, note.num, xml_escape(note.text)
+            '<aside epub:type="footnote" id="wt_%d" class="footnote weread-book-footnote"><p><a href="#wtref_%d" class="fn-num">%s</a> %s</p></aside>\n',
+            note_idx, note_idx, note.num, body_html
         )
     end
 
@@ -412,40 +1068,77 @@ function Footnotes.process(html, meta)
     end
 
     local local_index = Footnotes.index_anchors(html)
-    local refs = Footnotes.collect_cross_file_refs(html)
+    local refs = Footnotes.collect_footnote_refs(html)
+    local html1, img_notes = Footnotes.convert_img_footnotes(html)
+
     if #refs == 0 then
-        local converted, img_notes = Footnotes.convert_img_footnotes(html)
-        local section = build_footnote_section(img_notes, {})
-        return converted, section
+        local section = build_footnote_section(html1, img_notes, {})
+        return html1, section
     end
 
     local missing = {}
-    local ref_files = {}
-    local file_seen = {}
+    local ref_by_anchor = {}
     for _, ref in ipairs(refs) do
         if not local_index[ref.anchor] then
             missing[#missing + 1] = ref.anchor
-        end
-        if ref.file and not file_seen[ref.file] then
-            file_seen[ref.file] = true
-            ref_files[#ref_files + 1] = ref.file
+            if ref.file then
+                ref_by_anchor[ref.anchor] = ref.file
+            end
         end
     end
 
-    local remote = Footnotes.fetch_missing_anchors(meta, missing, ref_files)
+    if meta and meta.book_dir and next(local_index) then
+        local anchor_cache = Footnotes.load_anchor_cache(meta.book_dir)
+        local cache_updated = false
+        for anchor, text in pairs(local_index) do
+            if text and text ~= "" and not is_trivial_footnote_text(text)
+                and (not anchor_cache[anchor] or is_trivial_footnote_text(anchor_cache[anchor])) then
+                anchor_cache[anchor] = text
+                cache_updated = true
+            end
+        end
+        if cache_updated then
+            Footnotes.save_anchor_cache(meta.book_dir, anchor_cache)
+        end
+    end
+
+    local remote = Footnotes.fetch_missing_anchors(meta, missing, ref_by_anchor)
     local anchor_texts = {}
     for _, ref in ipairs(refs) do
         anchor_texts[ref.anchor] = local_index[ref.anchor] or remote[ref.anchor]
     end
 
-    local html1, img_notes = Footnotes.convert_img_footnotes(html)
-    local html2, cross_notes = Footnotes.convert_cross_file_footnotes(html1, anchor_texts, #img_notes)
-    local section = build_footnote_section(img_notes, cross_notes)
+    local html2, cross_notes = Footnotes.convert_footnote_refs(html1, anchor_texts, #img_notes)
+
+    local converted_anchors = {}
+    for _, note in ipairs(cross_notes) do
+        if note.anchor then
+            converted_anchors[note.anchor] = true
+        end
+    end
+    local next_fn_idx = #img_notes + #cross_notes
+    for _, ref in ipairs(refs) do
+        if not converted_anchors[ref.anchor] then
+            local text = anchor_texts[ref.anchor]
+            if text and text ~= "" and not is_trivial_footnote_text(text) then
+                next_fn_idx = next_fn_idx + 1
+                cross_notes[#cross_notes + 1] = {
+                    num = "[" .. ref.num .. "]",
+                    text = text,
+                    anchor = ref.anchor,
+                    fn_idx = next_fn_idx,
+                }
+            end
+        end
+    end
+
+    local section = build_footnote_section(html2, img_notes, cross_notes)
+    html2 = Footnotes.strip_consumed_footnote_blocks(html2, cross_notes)
 
     if section ~= "" then
-        if logger then logger.info(LOG_MODULE, "footnotes converted:", #img_notes + #cross_notes, "notes") end
+        log_info("footnotes converted:", #img_notes + #cross_notes, "notes")
     elseif #refs > 0 then
-        if logger then logger.info(LOG_MODULE, "footnotes refs found but content missing:", #refs) end
+        log_info("footnotes refs found but content missing:", #refs)
     end
     return html2, section
 end

--- a/weread/lib/footnotes.lua
+++ b/weread/lib/footnotes.lua
@@ -169,12 +169,11 @@ local function num_from_link_context(link)
     if type(link) ~= "string" then return nil end
     local id = link:match('id="([^"]+)"')
     local fragment = href_fragment(link:match('href="([^"]+)"') or "")
-    for _, token in ipairs({ id, fragment }) do
+    for _, token in ipairs({ id or fragment, id and fragment }) do
         if token then
             local num = token:match("_(%d+)_")
                 or token:match("^(%d+)$")
                 or token:match("_(%d+)$")
-                or token:match("(%d+)$")
             if num then return num end
         end
     end

--- a/weread/lib/footnotes.lua
+++ b/weread/lib/footnotes.lua
@@ -130,7 +130,9 @@ local function is_trivial_footnote_text(text)
     if type(text) ~= "string" or text == "" then
         return true
     end
-    return text:match("^%[%d+%]$") ~= nil or text:match("^%(%d+%)$") ~= nil
+    return text:match("^%[%d+%]$") ~= nil
+        or text:match("^%(%d+%)$") ~= nil
+        or text:match("^（%d+）$") ~= nil
 end
 
 local function cleanup_footnote_text(text)
@@ -138,10 +140,13 @@ local function cleanup_footnote_text(text)
     if text == "" then return "" end
     text = text:gsub("^%[%d+%]%s*", "")
     text = text:gsub("^%(%d+%)%s*", "")
+    text = text:gsub("^（%d+）%s*", "")
+    text = text:gsub("^　+", "")
     text = text:gsub("^%*%s*", "")
     return text:match("^%s*(.-)%s*$") or ""
 end
 
+--- 从脚注链接 inner HTML 提取编号（[N] / (N) / 全角（N），兼容 super/sup/text-sup 等）。
 local function extract_footnote_num(inner)
     if type(inner) ~= "string" then return nil end
     local text = strip_tags(inner)
@@ -150,6 +155,8 @@ local function extract_footnote_num(inner)
         or text:match("%[(%d+)%]")
         or text:match("^%((%d+)%)$")
         or text:match("%((%d+)%)")
+        or text:match("^（(%d+)）$")
+        or text:match("（(%d+)）")
 end
 
 local function link_inner_html(link)
@@ -178,6 +185,42 @@ local function num_from_link_context(link)
         end
     end
     return nil
+end
+
+local function has_footnote_reference_cue(link)
+    if type(link) ~= "string" then return false end
+    return link:find("text-sup", 1, true) ~= nil
+        or link:find("reader_footer_note", 1, true) ~= nil
+        or link:find('class="super"', 1, true) ~= nil
+        or link:find('class="super ', 1, true) ~= nil
+        or link:find("<sup", 1, true) ~= nil
+end
+
+--- 互链定义端：与正文引用成对；优先看引用样式，其次看是否为段首回链。
+-- normalize_markup 可能去掉 text-sup，因此不能仅靠样式判断。
+local function is_reciprocal_definition_link(link, reciprocal, html)
+    if type(link) ~= "string" or type(reciprocal) ~= "table" then
+        return false
+    end
+    local id = link:match('id="([^"]+)"')
+    local target = href_fragment(link:match('href="([^"]+)"') or "")
+    if not id or not target or reciprocal[id] ~= target then
+        return false
+    end
+    if has_footnote_reference_cue(link) then
+        return false
+    end
+    if type(html) == "string" and html ~= "" then
+        local esc = escape_pattern(id)
+        if html:find('<p[^>]*>%s*<a[^>]-id="' .. esc .. '"', 1) then
+            return true
+        end
+        local partner = html:match('<a[^>]-id="' .. escape_pattern(target) .. '"[^>]*>.-</a>')
+        if partner and has_footnote_reference_cue(partner) then
+            return true
+        end
+    end
+    return false
 end
 
 local function footnote_num_from_link(link)
@@ -348,25 +391,35 @@ local function replace_sup_paren_with_span_bracket(html)
     return html:gsub("<sup>%((%d+)%)%</sup>", "<span>[%1]</span>")
 end
 
+--- 将单个脚注 <a> 内部的 (N) / （N） / reader_footer_note 转为 <span>[N]</span>。
 local function normalize_footnote_link_tag(a_tag)
     if type(a_tag) ~= "string" then return a_tag end
+    local open = a_tag:match("^(<a%s+[^>]*>)")
+    if not open then return a_tag end
 
     if a_tag:find("reader_footer_note", 1, true) then
         local num = footnote_num_from_link(a_tag) or "1"
-        local open = a_tag:match("^(<a%s+[^>]*>)")
-        if open then
-            return open .. "<span>[" .. num .. "]</span></a>"
-        end
+        return open .. "<span>[" .. num .. "]</span></a>"
     end
 
-    if a_tag:find("<sup", 1, true) and a_tag:find("%(%d+%)", 1, false) then
-        local num = a_tag:match("<span[^>]*>%((%d+)%)</span>")
+    local num = extract_footnote_num(link_inner_html(a_tag))
+    if num and has_footnote_reference_cue(a_tag) then
+        if a_tag:find("text-sup", 1, true) then
+            return open .. '<span class="text-sup">[' .. num .. "]</span></a>"
+        end
+        if a_tag:find('class="super"', 1, true) or a_tag:find('class="super ', 1, true) then
+            return open .. '<span class="super">[' .. num .. "]</span></a>"
+        end
+        return open .. "<span>[" .. num .. "]</span></a>"
+    end
+
+    if a_tag:find("<sup", 1, true) and (a_tag:find("%(%d+%)", 1, false) or a_tag:find("（%d+）", 1, false)) then
+        local n = a_tag:match("<span[^>]*>%((%d+)%)</span>")
             or a_tag:match("<sup[^>]*>%((%d+)%)</sup>")
-        if num then
-            local open = a_tag:match("^(<a%s+[^>]*>)")
-            if open then
-                return open .. "<span>[" .. num .. "]</span></a>"
-            end
+            or a_tag:match("<span[^>]*>（(%d+)）</span>")
+            or a_tag:match("<sup[^>]*>（(%d+)）</sup>")
+        if n then
+            return open .. "<span>[" .. n .. "]</span></a>"
         end
         return replace_sup_paren_with_span_bracket(a_tag)
     end
@@ -487,7 +540,7 @@ local function extract_fn_content_body(html, anchor)
     body = body:gsub("^(%s*<a[^>]->.-</a>%s*)", function(prefix)
         if stripped then return prefix end
         local label = strip_tags(prefix)
-        if label:match("^%[%d+%]$") or label:match("^%(%d+%)$") then
+        if label:match("^%[%d+%]$") or label:match("^%(%d+%)$") or label:match("^（%d+）$") then
             stripped = true
             return ""
         end
@@ -669,19 +722,24 @@ function Footnotes.collect_footnote_refs(html)
         return refs
     end
 
+    local reciprocal = discover_reciprocal_anchors(html)
     local masked = mask_protected_blocks(html)
 
     for link in masked:gmatch(TEXT_FOOTNOTE_LINK_SCAN_RE) do
-        local parsed = parse_footnote_reference_link(link)
-        if parsed then
-            add_footnote_ref(refs, seen, parsed.anchor, parsed.num, parsed.file, parsed.href)
+        if not is_reciprocal_definition_link(link, reciprocal, html) then
+            local parsed = parse_footnote_reference_link(link)
+            if parsed then
+                add_footnote_ref(refs, seen, parsed.anchor, parsed.num, parsed.file, parsed.href)
+            end
         end
     end
 
     for link in masked:gmatch(LOCAL_HASH_LINK_SCAN_RE) do
-        local parsed = is_publisher_footnote_link(link) and parse_footnote_reference_link(link)
-        if parsed then
-            add_footnote_ref(refs, seen, parsed.anchor, parsed.num, nil, parsed.href)
+        if not is_reciprocal_definition_link(link, reciprocal, html) then
+            local parsed = is_publisher_footnote_link(link) and parse_footnote_reference_link(link)
+            if parsed then
+                add_footnote_ref(refs, seen, parsed.anchor, parsed.num, nil, parsed.href)
+            end
         end
     end
 
@@ -964,15 +1022,18 @@ function Footnotes.convert_footnote_refs(html, anchor_texts, fn_offset)
         )
     end
 
+    local reciprocal = discover_reciprocal_anchors(html)
     local masked, protected_blocks = mask_protected_blocks(html)
     masked = strip_empty_marker_anchors(masked)
     local result = masked:gsub(TEXT_FOOTNOTE_LINK_SCAN_RE, function(link)
+        if is_reciprocal_definition_link(link, reciprocal, html) then return link end
         local parsed = parse_footnote_reference_link(link)
         if not parsed then return link end
         return replace_footnote_link(parsed.anchor, parsed.num)
     end)
     result = result:gsub(LOCAL_HASH_LINK_SCAN_RE, function(link)
         if link:find('epub:type="noteref"', 1, false) or link:find('href="#wt_', 1, false) then return link end
+        if is_reciprocal_definition_link(link, reciprocal, html) then return link end
         local parsed = parse_footnote_reference_link(link)
         if not parsed then return link end
         return replace_footnote_link(parsed.anchor, parsed.num)
@@ -1010,6 +1071,8 @@ function Footnotes.strip_consumed_footnote_blocks(html, cross_notes)
         body = body:gsub("<p[^>]-class=\"fnContent[^\"]*\"[^>]->.-#" .. esc .. "\".-</p>%s*", "")
         body = body:gsub("<p[^>]-class=\"note\"[^>]->.-id=\"" .. esc .. "\".-</p>%s*", "")
         body = body:gsub("<p[^>]-class=\"note\"[^>]->.-#" .. esc .. "\".-</p>%s*", "")
+        body = body:gsub("<p[^>]-class=\"content\"[^>]*>%s*<a[^>]-id=\"" .. esc .. "\"[^>]*>.-</a>.-</p>%s*", "")
+        body = body:gsub("<p[^>]-class=\"content\"[^>]*>%s*<a[^>]-href=\"#" .. esc .. "\"[^>]*>.-</a>.-</p>%s*", "")
         return body
     end
 


### PR DESCRIPTION
- Add lib/footnotes.lua for img footnotes and cross-file Text/*.xhtml links
- Integrate footnote processing into the content download pipeline with EPUB3 inline footnote styles
- Pass chapters state during full-book downloads for cross-chapter anchor lookup

添加书籍脚注及尾注转换注入功能 fix #25 