### PR TITLE
fix: use high-resolution cover URLs when embedding EPUB covers

### DIFF
--- a/lib/weread.lua
+++ b/lib/weread.lua
@@ -188,4 +188,12 @@ function WeRead.mp_reader_url(book_id)
     return "https://weread.qq.com/web/mp/reader/" .. WeRead.e(book_id)
 end
 
+--- Upgrade WeRead CDN cover URLs to the higher-resolution t9 token.
+function WeRead.normalize_cover_url(url)
+    if type(url) ~= "string" or url == "" then
+        return url
+    end
+    return url:gsub("/t%d+_", "/t9_")
+end
+
 return WeRead

--- a/main.lua
+++ b/main.lua
@@ -1991,8 +1991,9 @@ function WeReadPlugin:_downloadStep(dl)
 
     if dl.index > dl.total then
         local cover_data
-        if dl.book.cover then
-            pcall(function() cover_data = self.client:get_binary(dl.book.cover) end)
+        local cover_url = WeRead.normalize_cover_url(dl.book.cover)
+        if cover_url and cover_url ~= "" then
+            pcall(function() cover_data = self.client:get_binary(cover_url) end)
         end
         local ok, path = pcall(function()
             return Content.save_book_epub(


### PR DESCRIPTION
Upgrade WeRead CDN cover paths from shelf thumbnail tokens (e.g. t5) to t9 before downloading.

使用高清封面图