### PR TITLE
fix: merge all body sections when building chapter XHTML

### DIFF
--- a/lib/content.lua
+++ b/lib/content.lua
@@ -301,8 +301,7 @@ local function body_fragment(xhtml)
         remaining = remaining:sub(body_close + 7)
     end
     if #bodies > 0 then
-        return table.concat(bodies, "
-")
+        return table.concat(bodies, "\n")
     end
     xhtml = xhtml:gsub("<%?xml.-%?>", "")
     xhtml = xhtml:gsub("<!DOCTYPE.-%>", "")

--- a/lib/content.lua
+++ b/lib/content.lua
@@ -277,12 +277,32 @@ local function xml_escape(value)
     return value
 end
 
+-- WeRead EPUB chapters may decode to multiple concatenated XHTML documents.
+-- The first <body> is often a title shell; main content lives in later bodies.
 local function body_fragment(xhtml)
     xhtml = tostring(xhtml or "")
-    local body = xhtml:match("<body[^>]*>(.-)</body>")
-        or xhtml:match("<body[^>]*>(.*)")
-    if body then
-        return body
+    local bodies = {}
+    local remaining = xhtml
+    while remaining ~= "" do
+        local body_start = remaining:find("<body", 1, true)
+        if not body_start then
+            break
+        end
+        local body_open_end = remaining:find(">", body_start, true)
+        if not body_open_end then
+            break
+        end
+        local body_close = remaining:find("</body>", body_open_end, true)
+        if not body_close then
+            bodies[#bodies + 1] = remaining:sub(body_open_end + 1)
+            break
+        end
+        bodies[#bodies + 1] = remaining:sub(body_open_end + 1, body_close - 1)
+        remaining = remaining:sub(body_close + 7)
+    end
+    if #bodies > 0 then
+        return table.concat(bodies, "
+")
     end
     xhtml = xhtml:gsub("<%?xml.-%?>", "")
     xhtml = xhtml:gsub("<!DOCTYPE.-%>", "")


### PR DESCRIPTION
Some WeRead EPUB chapters decode to multiple concatenated XHTML documents. The first body only contains the chapter title; the main text lives in later body sections. Concatenate all bodies instead of stopping at the first </body>.

部分书籍的章节是由多个 XHTML 组成，应进行拼接
fix #26 