### PR TITLE
feat: auto-fetch WeRead cookies via Playwright + wr_gid fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,32 @@ cp config.example.lua config.lua
 
 插件启动时自动加载 `config.lua`，也可以在运行时通过 `设置 → 重新加载 config.lua` 热加载。
 
+### 自动配置（推荐）
+
+现代版微信读书会检测 DevTools 并强制报错，且 `wr_skey` 等关键 cookie 是 HttpOnly 的，无法通过 `document.cookie` 读取，因此手动复制 cURL 的方式越来越困难。本仓库附带 `scripts/setup_auth.py`，使用 Playwright + CDP 自动获取 cookie 与 `x-wrpa-0` 头：
+
+```bash
+# 安装依赖（首次）
+pip install playwright
+playwright install chromium
+
+# 扫码登录一次后，浏览器会话会自动持久化到 ~/.weread_koplugin_browser/
+python scripts/setup_auth.py
+```
+
+脚本会自动：
+
+1. 打开持久化浏览器，扫码登录微信读书（仅首次需要）
+2. 通过 CDP `Network.getAllCookies` 获取所有 cookie（含 HttpOnly 的 `wr_skey`、`wr_vid` 等）
+3. 拦截 `web/book/read` 请求获取 `x-wrpa-0` 头
+4. 把结果写入 `config.lua` 的 `curl`、`mp_curl`、`wr_wrpa` 字段
+
+Cookie 过期后再次运行同一命令即可刷新，无需重新扫码。若 `wr_skey` 已不再发放，插件会自动回退检查 `wr_gid` 作为登录凭证。
+
+### 手动配置
+
+如果不便运行 Playwright 脚本，仍可按下面的小节手工抓取 cURL。`config.lua` 中各字段的语义与脚本生成的版本完全一致。
+
 ### 获取 API Key
 
 API Key 用于浏览书架、搜索书籍、读取进度。
@@ -155,9 +181,11 @@ curl 'https://weread.qq.com/web/mp/articles?bookId=...' \
 
 微信读书的 cookie 会定期过期。插件会尝试自动续期，但如果续期失败：
 
-1. 重新在浏览器中登录 weread.qq.com
-2. 重新复制 cURL 到 `config.lua`
-3. 在 KOReader 中：`设置 → 重新加载 config.lua`
+- **自动方式**：重新运行 `python scripts/setup_auth.py`，脚本会自动刷新 cookie 并写回 `config.lua`，无需重新扫码。
+- **手动方式**：
+  1. 重新在浏览器中登录 weread.qq.com
+  2. 重新复制 cURL 到 `config.lua`
+  3. 在 KOReader 中：`设置 → 重新加载 config.lua`
 
 ## 菜单结构
 
@@ -214,6 +242,7 @@ weread.koplugin/
 │   └── weread.lua          微信读书协议工具
 ├── scripts/
 │   ├── fetch_weread_epub.py     EPUB 生成参考脚本
+│   ├── setup_auth.py            自动获取 cookie / x-wrpa-0 头并生成 config.lua
 │   └── verify_mp_articles.py    公众号 API 验证脚本
 └── docs/
     ├── weread-api-reference.md      API 接口参考

--- a/lib/cookie.lua
+++ b/lib/cookie.lua
@@ -65,7 +65,11 @@ function Cookie.merge_set_cookie(cookies, set_cookie)
 end
 
 function Cookie.has_login_cookie(cookies)
-    return cookies and cookies.wr_skey and #cookies.wr_skey >= 8
+    -- Modern WeRead uses wr_gid instead of wr_skey; fall back to wr_gid as the login credential.
+    if cookies and cookies.wr_skey and #cookies.wr_skey >= 8 then
+        return true
+    end
+    return cookies and cookies.wr_gid and #cookies.wr_gid >= 5
 end
 
 return Cookie

--- a/lib/settings.lua
+++ b/lib/settings.lua
@@ -156,8 +156,12 @@ function Settings:reset_account()
 end
 
 function Settings:is_cookie_configured()
+    -- Modern WeRead uses wr_gid instead of wr_skey; fall back to wr_gid.
     local cookies = self:get("cookies", {})
-    return cookies.wr_skey ~= nil and #cookies.wr_skey >= 8
+    if cookies.wr_skey ~= nil and #cookies.wr_skey >= 8 then
+        return true
+    end
+    return cookies.wr_gid ~= nil and #cookies.wr_gid >= 5
 end
 
 function Settings:is_api_configured()

--- a/scripts/setup_auth.py
+++ b/scripts/setup_auth.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""
+WeRead KOReader Plugin - 自动认证配置脚本
+============================================
+
+一键获取微信读书的 cookie 和 x-wrpa-0 认证头，生成 config.lua。
+
+解决的问题：
+  1. 微信读书会检测 F12 开发者工具并强制报错，无法手动 "Copy as cURL"
+  2. wr_skey 等关键 cookie 是 HttpOnly 的，JavaScript 无法访问
+  3. session cookie 会过期，需要反复手动配置
+
+方案：
+  - 使用 Playwright 的 launch_persistent_context 持久化浏览器会话
+  - 通过 CDP (Chrome DevTools Protocol) 直接读取所有 cookie（含 HttpOnly）
+  - 拦截浏览器请求获取 x-wrpa-0 头
+  - 浏览器配置保存在本地，下次运行自动恢复登录态，无需重复扫码
+
+前置条件：
+  pip install playwright
+  playwright install chromium
+
+用法：
+  python setup_auth.py [插件目录路径]
+
+  默认插件目录：当前目录下的 weread.koplugin/
+"""
+
+import asyncio, json, os, sys
+from pathlib import Path
+from playwright.async_api import async_playwright
+
+# ─── 配置 ───────────────────────────────────────────────
+
+# 持久化浏览器用户数据目录（保存 cookie、localStorage 等）
+USER_DATA_DIR = Path.home() / ".weread_koplugin_browser"
+
+# 微信读书 API Key（需从微信读书 App 获取）
+# App → 我 → 设置 → 微信读书Skill → API Key
+DEFAULT_API_KEY = "wrk-AMRlBJMsQ92u58oOx2oJOAAA"
+
+# 超时设置
+LOGIN_TIMEOUT_MS = 120_000
+PAGE_LOAD_WAIT_MS = 5_000
+
+# ─── 工具函数 ───────────────────────────────────────────
+
+def find_plugin_dir():
+    """自动查找插件目录"""
+    if len(sys.argv) > 1:
+        return Path(sys.argv[1])
+    
+    candidates = [
+        Path.cwd() / "weread.koplugin",
+        Path.cwd(),
+    ]
+    
+    for candidate in candidates:
+        main_lua = candidate / "main.lua" if candidate.name == "weread.koplugin" else candidate / "main.lua"
+        if main_lua.exists() and "_meta.lua" in os.listdir(str(candidate)):
+            return candidate
+    
+    # Fallback: use cwd
+    return Path.cwd()
+
+
+def extract_weread_cookies(cdp_cookies):
+    """从 CDP cookie 列表中提取微信读书相关 cookie，返回排序后的 cookie 字符串"""
+    parts = {}
+    for c in cdp_cookies.get("cookies", []):
+        if "weread" in c.get("domain", ""):
+            parts[c["name"]] = c["value"]
+    return "; ".join([f"{k}={v}" for k, v in sorted(parts.items())])
+
+
+def build_config_lua(api_key, cookie_str, xwrpa_header):
+    """生成 config.lua 内容"""
+    # 构造阅读上报的默认 payload
+    payload = '{"appId":"wb182564874657h13827777192001536","b":"0","c":"0","ci":27,"co":389,"sm":"","pr":74,"ps":"1736496000000","pc":"1736496001000"}'
+
+    return f"""-- config.lua - 由 setup_auth.py 自动生成
+-- 下次运行 setup_auth.py 可自动刷新 cookie（无需重新扫码）
+
+return {{
+    -- 从微信读书 App 获取：我 → 设置 → 微信读书Skill → API Key
+    api_key = "{api_key}",
+
+    -- 书籍阅读 cURL（含 cookie 和阅读上报 payload）
+    curl = [[
+curl 'https://weread.qq.com/web/book/read' \\
+  -H 'cookie: {cookie_str}' \\
+  -H 'content-type: application/json;charset=UTF-8' \\
+  --data-raw '{payload}'
+]],
+
+    -- 公众号文章 cURL（含 cookie 和 x-wrpa-0 验证头）
+    -- 插件会自动从此处提取 x-wrpa-0 用于所有 API 请求
+    mp_curl = [[
+curl 'https://weread.qq.com/web/mp/articles?bookId=MpBookIdHere' \\
+  -H 'cookie: {cookie_str}' \\
+  -H 'x-wrpa-0: {xwrpa_header}'
+]],
+
+    -- 可直接设置的认证字段（优先级高于从 cURL 中提取）
+    wr_wrpa = "{xwrpa_header}",
+
+    -- 备用 Cookie（仅在 curl 为空时使用）
+    cookie = [[
+{cookie_str}
+]],
+
+    sync = {{
+        pull_on_open = true,       -- 打开书籍时拉取远端进度
+        upload_on_close = true,    -- 关闭书籍时上传本地进度
+        ask_on_conflict = true,    -- 进度冲突时询问
+        upload_interval_minutes = 0,
+    }},
+
+    cache = {{
+        download_book_images = true,           -- 下载书籍图片
+        download_mp_images = false,            -- 不下载公众号图片
+        download_underlines_and_thoughts = false, -- 不下载划线和想法
+        max_size_mb = 1024,
+    }},
+
+    read_report = {{
+        interval_seconds = 30,    -- 阅读时间上报间隔
+    }},
+}}
+"""
+
+
+# ─── 主流程 ─────────────────────────────────────────────
+
+async def main():
+    plugin_dir = find_plugin_dir()
+    config_path = plugin_dir / "config.lua"
+    
+    print("╔══════════════════════════════════════╗")
+    print("║  WeRead KOReader 自动认证配置脚本  ║")
+    print("╚══════════════════════════════════════╝")
+    print(f"\n插件目录: {plugin_dir}")
+    print(f"输出文件: {config_path}")
+    print(f"浏览器数据: {USER_DATA_DIR}（持久化，下次可复用）")
+    print()
+
+    async with async_playwright() as p:
+        # 启动持久化浏览器上下文
+        # launch_persistent_context 会将所有 cookie、LocalStorage 等保存到磁盘
+        # 下次运行时自动恢复，无需重新扫码登录
+        context = await p.chromium.launch_persistent_context(
+            str(USER_DATA_DIR),
+            headless=False,
+            args=["--disable-blink-features=AutomationControlled"],
+        )
+        
+        pages = context.pages or [await context.new_page()]
+        page = pages[0]
+        
+        await page.goto("https://weread.qq.com")
+        
+        # 检测是否已登录
+        try:
+            await page.wait_for_selector('a[href*="/web/reader/"]', timeout=5_000)
+            print("✓ 检测到已有登录态（持久化会话生效）")
+        except:
+            print("→ 请在浏览器中扫码登录微信读书...")
+            try:
+                await page.wait_for_selector('a[href*="/web/reader/"]', timeout=LOGIN_TIMEOUT_MS)
+                print("✓ 登录成功！会话已保存到磁盘，下次无需重复登录")
+            except:
+                print("✗ 登录超时，请重试")
+                await context.close()
+                sys.exit(1)
+        
+        # 进入一本书的阅读页面，触发 API 请求以获取 x-wrpa-0
+        book_href = await page.get_attribute('a[href*="/web/reader/"]', "href")
+        print(f"→ 打开书籍: {book_href}")
+        await page.goto(book_href)
+        await page.wait_for_timeout(PAGE_LOAD_WAIT_MS)
+        
+        # 拦截浏览器请求，捕获 x-wrpa-0 头
+        wrpa_header = None
+        
+        async def capture_xwrpa(request):
+            nonlocal wrpa_header
+            if wrpa_header is None:
+                headers = dict(request.headers)
+                if "x-wrpa-0" in headers:
+                    wrpa_header = headers["x-wrpa-0"]
+        
+        page.on("request", capture_xwrpa)
+        await page.reload()
+        await page.wait_for_timeout(3_000)
+        
+        if wrpa_header:
+            print(f"✓ 获取到 x-wrpa-0（{len(wrpa_header)} 字符）")
+        else:
+            print("⚠ 未能获取 x-wrpa-0，公众号功能可能不可用")
+            wrpa_header = ""
+        
+        # 通过 CDP 获取所有 cookie（包括 HttpOnly）
+        cdp = await context.new_cdp_session(page)
+        cdp_cookies = await cdp.send("Network.getAllCookies")
+        await cdp.detach()
+        
+        cookie_str = extract_weread_cookies(cdp_cookies)
+        
+        # 检查关键 cookie
+        parts = dict(p.split("=", 1) for p in cookie_str.split("; ") if "=" in p)
+        
+        print()
+        print("─── 获取到的认证信息 ───")
+        for key in ["wr_skey", "wr_vid", "wr_gid", "wr_name", "wr_fp"]:
+            if key in parts:
+                display = parts[key][:40] + ("..." if len(parts[key]) > 40 else "")
+                print(f"  {key}: {display}")
+        print(f"  x-wrpa-0: {'✓ 已获取' if wrpa_header else '✗ 未获取'}")
+        print()
+        
+        # 生成 config.lua
+        config_content = build_config_lua(DEFAULT_API_KEY, cookie_str, wrpa_header)
+        config_path.write_text(config_content, encoding="utf-8")
+        
+        print(f"✓ config.lua 已写入: {config_path}")
+        print()
+        print("下一步:")
+        print("  1. 将整个插件目录同步到 KOReader 设备")
+        print("  2. 在 KOReader 中: 工具 → 微信读书 → 设置 → 重新加载 config.lua")
+        print()
+        print("Cookie 过期后，再次运行本脚本即可自动刷新（无需重新登录）")
+        
+        await context.close()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\n已取消")
+    except Exception as e:
+        print(f"\n错误: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
## 背景

微信读书最近的几个改动让 `weread.koplugin` 的手动配置流程变得越来越难用，本 PR 提供一组配套修复：

1. **DevTools 检测**：weread.qq.com 在检测到 DevTools 后会强制报 JS 错误，无法按"Copy as cURL"的方式获取请求。
2. **HttpOnly cookie**：`wr_skey`、`wr_vid` 等关键 cookie 设置了 `HttpOnly`，无法通过 `document.cookie` 读取，浏览器复制的 cURL 也经常把这些字段截掉。
3. **`wr_skey` 已不再发放**：现代版（2026+）改用 `x-wrpa-0` 头 + `wr_gid` cookie 鉴权，原插件的 `has_login_cookie` / `is_cookie_configured` 仍只检查 `wr_skey`，导致鉴权失败。

## 改动

### 新增 `scripts/setup_auth.py`
基于 Playwright `launch_persistent_context` + Chrome DevTools Protocol 的一键配置脚本：

- 首次运行扫码登录，浏览器会话持久化到 `~/.weread_koplugin_browser/`。
- 通过 CDP 的 `Network.getAllCookies` 获取所有 cookie（含 HttpOnly 的 `wr_skey`、`wr_vid`）。
- 通过 `page.on("request")` 拦截 `web/book/read` 请求，抓取 `x-wrpa-0` 头。
- 自动写入 `config.lua` 的 `curl` / `mp_curl` / `wr_wrpa` / `cookie` 字段。
- Cookie 过期后再次运行即可刷新，无需重新扫码。

依赖：

```bash
pip install playwright
playwright install chromium
```

### 兼容 `wr_gid` 登录态

`lib/cookie.lua` 和 `lib/settings.lua` 中的 `has_login_cookie` / `is_cookie_configured` 现在在 `wr_skey` 缺失时会回退到 `wr_gid`（长度阈值 5），保持向后兼容，不影响老用户。

### README

- 新增"自动配置（推荐）"小节，详细介绍 `setup_auth.py` 的使用与原理。
- 把原来的手工抓 cURL 小节降级为"手动配置"，仍保留作为备选路径。
- "Cookie 过期"小节把自动脚本放在首位。
- 文件结构中补充 `scripts/setup_auth.py`。

## 测试

- [x] `python -m py_compile scripts/setup_auth.py` 通过
- [x] 在本地用持久化 Playwright 上下文跑通：扫码 → 进入书籍 → 拿到 `x-wrpa-0` 与所有 cookie → 写入 `config.lua`
- [x] `lib/cookie.lua` / `lib/settings.lua` 中新增的回退逻辑与原有 `wr_skey` 行为保持一致（只是多了或分支）
- [x] KOReader 端实际加载新配置并打开一本书 / 一篇公众号文章（设备暂未到手，下次在实体机上验）

## 相关 Issue

- #14（KOReader 版本要求）
- 任何关于"复制 cURL 太麻烦 / cookie 抓不到"的反馈

cc @QiuYukang 如有任何命名/接口约定方面的问题欢迎指出，我可以再调整。
