### PR TITLE
 feat: prevent device standby during book downloads

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -14,6 +14,8 @@ local time = require("ui/time")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local T = require("ffi/util").template
+local Device = require("device")
+local PluginShare = require("pluginshare")
 
 local Cookie = require("lib.cookie")
 local Client = require("lib.client")
@@ -1177,6 +1179,71 @@ function WeReadPlugin:runOnlineTask(label, callback, delay)
     return true
 end
 
+
+-- Block OS-level standby (Kindle powerd, Kobo lid/menu-suspend, etc.)
+local function preventOsStandby()
+    if Device:isKindle() then
+        os.execute("lipc-set-prop com.lab126.powerd preventScreenSaver 1")
+    end
+    if Device:isCervantes() or Device:isKobo() then
+        PluginShare.pause_auto_suspend = true
+    end
+end
+
+local function allowOsStandby()
+    if Device:isKindle() then
+        os.execute("lipc-set-prop com.lab126.powerd preventScreenSaver 0")
+    end
+    if Device:isCervantes() or Device:isKobo() then
+        PluginShare.pause_auto_suspend = false
+    end
+end
+
+-- Keep the device awake during long book downloads.
+function WeReadPlugin:_beginDownloadStandby()
+    self._download_standby_ref = (self._download_standby_ref or 0) + 1
+    if self._download_standby_ref == 1 then
+        UIManager:preventStandby()
+        preventOsStandby()
+    end
+end
+
+function WeReadPlugin:_endDownloadStandby()
+    local ref = self._download_standby_ref or 0
+    if ref <= 0 then
+        return
+    end
+    self._download_standby_ref = ref - 1
+    if self._download_standby_ref == 0 then
+        UIManager:allowStandby()
+        allowOsStandby()
+    end
+end
+
+function WeReadPlugin:_releaseBookDownloadStandby(dl)
+    if dl and dl.standby_guard then
+        dl.standby_guard = nil
+        self:_endDownloadStandby()
+    end
+end
+
+function WeReadPlugin:_scheduleDownloadStep(dl, delay)
+    UIManager:scheduleIn(delay or 0.1, function()
+        local ok, err = xpcall(function()
+            self:_downloadStep(dl)
+        end, debug.traceback)
+        if not ok and dl.standby_guard then
+            self:_releaseBookDownloadStandby(dl)
+            if dl.progress_dialog then
+                dl.progress_dialog:close()
+                dl.progress_dialog = nil
+            end
+            logger.err(LOG_MODULE, "download step failed:", log_error(err))
+            self:showInfo(T(_("Download failed:\n%1"), display_error(err)))
+        end
+    end)
+end
+
 function WeReadPlugin:runNetworkAction(label, action)
     self:runOnlineTask(label, function()
         local ok, result = pcall(action)
@@ -2193,6 +2260,7 @@ function WeReadPlugin:downloadChaptersAsBook(book, chapters, suffix, options)
             return
         end
 
+        self:_beginDownloadStandby()
         local total = #chapters
         local dl = {
             book = book,
@@ -2209,6 +2277,7 @@ function WeReadPlugin:downloadChaptersAsBook(book, chapters, suffix, options)
             annotation_failed_batches = 0,
             single_chapter = options.single_chapter == true,
             started_at = time.now(),
+            standby_guard = true,
         }
 
         local progress_dialog = DownloadDialog:new{
@@ -2231,9 +2300,7 @@ function WeReadPlugin:downloadChaptersAsBook(book, chapters, suffix, options)
         progress_dialog:show()
         self:refreshUI()
 
-        UIManager:scheduleIn(0.1, function()
-            self:_downloadStep(dl)
-        end)
+        self:_scheduleDownloadStep(dl)
     end)
 end
 
@@ -2265,7 +2332,7 @@ function WeReadPlugin:_failCurrentDownloadChapter(dl, err)
     if dl.progress_dialog then
         dl.progress_dialog:reportProgress(dl.index - 1)
     end
-    UIManager:scheduleIn(0.1, function() self:_downloadStep(dl) end)
+    self:_scheduleDownloadStep(dl)
 end
 
 function WeReadPlugin:_finishCurrentDownloadChapter(dl)
@@ -2303,7 +2370,7 @@ function WeReadPlugin:_finishCurrentDownloadChapter(dl)
     if dl.progress_dialog then
         dl.progress_dialog:reportProgress(dl.index - 1)
     end
-    UIManager:scheduleIn(0.1, function() self:_downloadStep(dl) end)
+    self:_scheduleDownloadStep(dl)
 end
 
 function WeReadPlugin:_applyCurrentAnnotations(dl)
@@ -2336,6 +2403,7 @@ end
 
 function WeReadPlugin:_downloadAnnotationBatch(dl)
     if dl.cancelled then
+        self:_releaseBookDownloadStandby(dl)
         self:showTransientInfo(_("Download cancelled"), 2)
         return
     end
@@ -2427,6 +2495,7 @@ end
 
 function WeReadPlugin:_downloadStep(dl)
     if dl.cancelled then
+        self:_releaseBookDownloadStandby(dl)
         self:showTransientInfo(_("Download cancelled"), 2)
         return
     end
@@ -2437,6 +2506,7 @@ function WeReadPlugin:_downloadStep(dl)
                 dl.progress_dialog:close()
                 dl.progress_dialog = nil
             end
+            self:_releaseBookDownloadStandby(dl)
             logger.err(LOG_MODULE, "book download failed: no chapters downloaded")
             self:showInfo(_("No chapters were downloaded."))
             return
@@ -2467,6 +2537,7 @@ function WeReadPlugin:_downloadStep(dl)
             dl.progress_dialog:close()
             dl.progress_dialog = nil
         end
+        self:_releaseBookDownloadStandby(dl)
         local books = self.settings:get("books", {})
         local book_id = dl.book.book_id or dl.book.bookId
         if book_id then


### PR DESCRIPTION
Port UIManager:preventStandby/allowStandby from the reference downloader so long full-book or chapter downloads do not suspend mid-transfer. Also block OS-level standby (Kindle powerd, Kobo lid-suspend).

Wrap the incremental download step scheduler with xpcall and always release the standby guard on cancel, failure, or completion.

## 变更说明 / Summary

下载时禁止设备休眠防止下载中断

## 类型 / Type

- [ ] Bugfix / Bug 修复
- [x] Feature / 新功能
- [ ] Refactor / 重构
- [ ] Documentation / 文档
- [ ] Other / 其他

## 测试 / Testing

下载一本较多章节书籍（上千章），期间不出现锁屏或休眠。

- [ ] 已在 KOReader 中手动测试 / Manually tested in KOReader
- [ ] 已运行相关脚本或检查 / Ran relevant scripts or checks
- [ ] 不适用，仅文档或注释变更 / Not applicable, docs/comments only

## Checklist

- [x] 我已经说明这个 PR 解决的问题或新增的特性。 / I described the problem fixed or feature added.
- [ ] 如果是 bugfix，我已经提供复现步骤或关联 issue。 / For a bugfix, I provided reproduction steps or linked an issue.
- [ ] 如果是新增 UI/交互特性，我已经提供截图或录屏。 / For a new UI/interaction feature, I added screenshots or a screen recording.
- [ ] 我没有提交 `config.lua`、API key、cookie、`x-wrpa-*`、完整 cURL 或私人书籍内容。 / I did not commit `config.lua`, API keys, cookies, `x-wrpa-*`, full cURL commands, or private book content.
- [ ] 如果修改了用户可见文本，我已经更新 `lib/i18n.lua`。 / If I changed user-facing text, I updated `lib/i18n.lua`.
- [ ] 如果修改了菜单结构，我已经同步更新 README 菜单结构。 / If I changed menu structure, I updated the README menu tree.
- [ ] 如果涉及非公开 WeRead Web API，我已经先在 `scripts/` 中验证或说明验证方式。 / If this touches non-public WeRead Web APIs, I validated it in `scripts/` or described the validation.
