### PR TITLE
Refactor/thought popup UI and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 使用说明 / Usage guide
-    url: https://github.com/QiuYukang/weread.koplugin#readme
+    url: https://github.com/finlater/weread.koplugin#readme
     about: 提 issue 前请先阅读 README。Please read the README before opening an issue.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ lib/reader_state.lua    Web Reader session and position extraction
 lib/settings.lua        Settings persistence via KOReader LuaSettings
 lib/weread.lua          WeRead protocol utilities (encoding, signing, URL helpers)
 ui/download_dialog.lua  Custom download progress dialog with cancel button
+ui/thought_popup.lua    Underline/thought popup widget (ScrollHtmlWidget, font preheat)
 ```
 
 ## Key Conventions
@@ -128,3 +129,4 @@ These are placeholder menu items shown when a WeRead book is open, currently gre
 
 - `docs/weread-api-reference.md` — full API endpoint reference (gateway + Web)
 - `docs/weread-content-research.md` — content decoding and image packaging research
+- `docs/weread-annotations-flow.md` — underline/thought download → embed → tap-to-display flow

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 
 ## 安装
 
-> ⚠️ 请使用**较新版本**的 KOReader，过旧的版本可能导致插件无法加载或启动失败（表现为「工具」菜单下找不到「微信读书」）。已知 `2024.11` 会出问题，`2026.3` 可正常使用；建议升级到最新版。详见 [#14](https://github.com/QiuYukang/weread.koplugin/issues/14)。
+> ⚠️ 请使用**较新版本**的 KOReader，过旧的版本可能导致插件无法加载或启动失败（表现为「工具」菜单下找不到「微信读书」）。已知 `2024.11` 会出问题，`2026.3` 可正常使用；建议升级到最新版。详见 [#14](https://github.com/finlater/weread.koplugin/issues/14)。
 
 将插件目录复制到 KOReader 的 plugins 目录：
 

--- a/docs/weread-annotations-flow.md
+++ b/docs/weread-annotations-flow.md
@@ -1,0 +1,98 @@
+# 划线与想法：下载 → 嵌入 → 展示完整链路
+
+本文说明「点击书籍正文里的划线，弹出该处的划线与想法」这一功能的端到端实现原理。
+
+## 一句话原理
+
+**下载时**把微信读书的划线 / 想法转换成 **EPUB 标准脚注结构**（`epub:type="noteref"` 引用链接 + `epub:type="footnote"` 脚注块）直接烧进 EPUB，想法脚注块用 CSS 隐藏；**阅读时**抢在 KOReader 内建脚注弹窗之前拦截点击，从被点节点提取那段隐藏的脚注 HTML，用自定义浮层渲染出来。
+
+核心巧思：**复用 EPUB 原生的 noteref / footnote 机制**承载数据（链接、定位由 CREngine 免费提供），但用 **CSS 隐藏 + 拦截点击 + 自定义浮层**接管展示，从而绕开 KOReader 内建脚注弹窗，并实现划线高亮、字体跟随、显隐开关等原生做不到的效果。展示阶段**完全离线**，不联网。
+
+## 数据流总览
+
+```
+微信读书 gateway API
+  /book/underlines   → 划线 range[]        ┐
+  /book/readreviews  → 想法 reviews[]       ┘
+        │ (下载时)
+        ▼  Annotations.process
+  原始章节 HTML ──► <a noteref href="#thought_UID_RANGE"><span wr-underline>划线</span>*</a>
+                   <aside footnote id="thought_UID_RANGE" class="weread-thought">想法…</aside>  (display:none)
+        │  save_book_epub
+        ▼
+   EPUB 文件（划线 + 想法已内嵌）
+        │ (阅读时，离线)
+        ▼  点击 → 拦截 tap_link → getHTMLFromXPointer 提取隐藏 aside
+   ThoughtPopup 底部浮层渲染想法
+```
+
+## 阶段一：下载（Download）
+
+前提：开启「下载划线和想法」（设置项 `cache.download_underlines_and_thoughts`）。在 `lib/downloader.lua` 的每章下载流程中：
+
+1. **拉划线** —— `_startAnnotations` → `Thoughts.fetch_underlines`（`lib/thoughts.lua`）→ `client:get_chapter_underlines`（`lib/client.lua`）→ gateway API **`/book/underlines`**。返回该章所有划线，每条带一个 `range`，如 `"383-415"` —— 这是**原始章节 HTML 的 rune（UTF-8 字符）索引区间**。
+2. **分批拉想法** —— 收集所有 range → `build_chapter_review_batches`（`lib/client.lua`，每 5 个 range 一批）→ `_annotationBatch` 逐批 → `get_chapter_reviews_batch` → gateway API **`/book/readreviews`**。返回每个 range 上的想法 `reviews`（含作者、内容、点赞数、引用原文 `abstract`）。批次间 0.3s 间隔 + 失败重试 2 次（防限流）。
+
+## 阶段二：嵌入 EPUB（Process & Save）
+
+`_applyAnnotations` → `Thoughts.apply_data`（`lib/thoughts.lua`）→ **`Annotations.process`**（`lib/annotations.lua`）。这是核心。
+
+> **关键约束**：range 是**原始 HTML 的字符索引**，因此注释注入必须在图片改写等步骤之前完成，否则索引会错位。
+
+### a) 注入下划线 `injectUnderlines`
+
+- 把 HTML 拆成 rune 数组（range 是字符索引，不是字节索引）；range 是 0 索引（JS 惯例）→ +1 转 Lua 1 索引。
+- `snapStartToSafeBoundary` / `snapEndToSafeBoundary`：把区间端点从 HTML 标签 / 实体内部挪出来，避免切坏标签。
+- `wrapTextSegments`：区间内的**文本段**逐段用 `<span class="wr-underline">` 包裹，遇标签自动断开重开（不跨标签边界）。
+- **若这条 range 有想法**：在最后一个下划线 span 末尾加 `<span class="wr-star">*</span>`（灰色星号上标），并把每个下划线 span 用 `<a epub:type="noteref" class="wr-thought-link" href="#thought_<chapterUid>_<range>">` 包起来 —— 即 EPUB 标准脚注引用链接（逐 span 包裹是为了避免块级边界导致 MuPDF 截断链接）。
+
+### b) 生成脚注块 `buildThoughtAsides`
+
+把想法内容拼成 `<aside epub:type="footnote" id="thought_<uid>_<range>" class="footnote weread-thought">`（含引用原文、作者 + 点赞、正文），注入到 `</body>` 之前。
+
+### CSS（`Annotations.UNDERLINE_CSS` / `THOUGHT_CSS`）
+
+- `.wr-underline`：橙色虚线下划线。
+- `.wr-star`：灰色小星号上标。
+- **`.weread-thought{display:none}`**：想法脚注块在正文里**隐藏**，正常阅读看不到。
+
+处理后的 HTML + 注释 CSS 经 `Thoughts.merge_css` 合并，最终由 `Content.save_book_epub` 打包。想法同时另存一份 `thoughts/<chapter_uid>.json` 缓存（`Thoughts.save_cache`）。**至此，划线和想法已固化在 EPUB 文件内。**
+
+## 阶段三：阅读时展示（Display）
+
+### 打开书 `onReaderReady`（`main.lua`）
+
+- 检测是 WeRead 书 → `_setupThoughtInterception`：注册一个**覆盖全屏的 tap 手势区**，`overrides = {"tap_link"}` —— **抢在 KOReader 内建的脚注弹窗（tap_link）之前**接管点击。
+- `applyAnnotationVisibility`：按 `show_annotations` 开关，决定是否往排版样式表追加隐藏注释的 CSS —— 这就是「显示 / 隐藏划线」开关的实现。
+- **预热** `ThoughtPopup.prewarm`（`ui/thought_popup.lua`）：用占位 HTML 提前创建一次渲染 widget，把 MuPDF 引擎 / 字体 / CSS 缓存热起来，让首次点击不卡。
+
+### 点击划线 `_onThoughtTap`（`main.lua`）
+
+1. `self.ui.link:getLinkFromGes(ges)` 拿到点击处链接 —— 因为划线被 `<a href="#thought_...">` 包裹，KOReader 把它当作 link，返回 `link.xpointer`（指向目标 aside 节点）。
+2. `getHTMLFromXPointer(link.xpointer, 0x1001, false)` 提取**那一个 aside 节点**的 HTML。第三参数 `false` 很关键：不扩展到父节点，否则会把整个 footnotes section（上百条脚注）全拉出来，MuPDF 会卡死。结果按 `xpointer` 缓存。
+3. 校验提取的 HTML 含 `weread-thought` 标记。
+4. 若 `show_annotations == false`：只 `return true` **吃掉这次点击**（阻止内建脚注弹窗弹出），但不显示自己的浮层。
+5. 否则 `return true` 消费点击，`nextTick` 里调 `_showThoughtPopup`。
+
+### 渲染浮层 `_showThoughtPopup` → `ThoughtPopup.show`
+
+- 先 `highlightXPointer` 高亮被点的划线原文。
+- 把提取的 aside HTML 交给 `ScrollHtmlWidget`（内部 MuPDF/CRE 渲染 xhtml 片段），渲成**底部浮层**（默认屏高 35%，按内容自适应）。
+- 浮层自带 CSS 把 `.weread-thought` 重新设为**可见**（浮层是独立文档，不继承正文那条隐藏 CSS），并配字体 fallback 链（书籍字体 → Noto Sans → emoji）。
+- **单例池** `_pooled_popup`：第二次点击直接 `_reopen` 换内容重排，不重建 widget，更快。
+- 点空白 / 左右下滑关闭；关闭时清掉原文高亮。
+
+### 防错机制 `_reader_session_gen`
+
+每次开 / 关书都 +1，所有异步回调都校验它是否一致 —— 防止翻页或关书后，先前排队的异步浮层错误弹出。
+
+## 涉及文件
+
+| 文件 | 职责 |
+|------|------|
+| `lib/downloader.lua` | 下载状态机，逐章调用划线/想法抓取与嵌入 |
+| `lib/client.lua` | gateway API：`/book/underlines`、`/book/readreviews`，range 分批 |
+| `lib/thoughts.lua` | 下载编排、想法 JSON 缓存、CSS 合并 |
+| `lib/annotations.lua` | 核心：把划线/想法注入 HTML（下划线 span + noteref 链接 + footnote aside） |
+| `ui/thought_popup.lua` | 展示：ScrollHtmlWidget 底部浮层、字体预热、单例复用 |
+| `main.lua` | tap 拦截、xpointer 提取、显隐开关、会话防错 |

--- a/lib/i18n.lua
+++ b/lib/i18n.lua
@@ -229,7 +229,7 @@ local zh = {
     ["You have reached the last chapter."] = "已经是最后一章了。",
     ["WIP"] = "开发中",
     ["About (v%1)"] = "关于（v%1）",
-    ["WeRead Plugin v%1\n\nDisclaimer: This project is for personal learning and technical research only, not for commercial use. All consequences arising from the use of this project (including but not limited to account bans, data loss, etc.) are borne by the user. The project author assumes no responsibility. Please comply with WeRead's user agreement and applicable laws and regulations.\n\nhttps://github.com/qiuyukang/weread.koplugin"] = "WeRead 插件 v%1\n\n免责声明：本项目仅供个人学习和技术研究使用，不得用于商业用途。使用本项目所产生的一切后果（包括但不限于账号封禁、数据丢失等）由使用者自行承担，项目作者概不负责。请遵守微信读书的用户协议和相关法律法规。\n\nhttps://github.com/qiuyukang/weread.koplugin",
+    ["WeRead Plugin v%1\n\nDisclaimer: This project is for personal learning and technical research only, not for commercial use. All consequences arising from the use of this project (including but not limited to account bans, data loss, etc.) are borne by the user. The project author assumes no responsibility. Please comply with WeRead's user agreement and applicable laws and regulations.\n\nhttps://github.com/finlater/weread.koplugin"] = "WeRead 插件 v%1\n\n免责声明：本项目仅供个人学习和技术研究使用，不得用于商业用途。使用本项目所产生的一切后果（包括但不限于账号封禁、数据丢失等）由使用者自行承担，项目作者概不负责。请遵守微信读书的用户协议和相关法律法规。\n\nhttps://github.com/finlater/weread.koplugin",
     ["QR code login"] = "微信扫码登录",
     ["Unknown"] = "未知",
     -- Reading statistics

--- a/main.lua
+++ b/main.lua
@@ -26,7 +26,7 @@ local ReadStats = require("lib.read_stats")
 local ReadStatsView = require("ui.read_stats_view")
 local Settings = require("lib.settings")
 local WeRead = require("lib.weread")
-local ThoughtPopup = require("lib.thought_popup")
+local ThoughtPopup = require("ui.thought_popup")
 
 -- `_` is the translation function; never reuse it as a loop placeholder in this file.
 local function _(text)

--- a/main.lua
+++ b/main.lua
@@ -255,7 +255,7 @@ function WeReadPlugin:getMainMenuItems()
             text = T(_("About (v%1)"), self.version),
             callback = function()
                 UIManager:show(InfoMessage:new{
-                    text = T(_("WeRead Plugin v%1\n\nDisclaimer: This project is for personal learning and technical research only, not for commercial use. All consequences arising from the use of this project (including but not limited to account bans, data loss, etc.) are borne by the user. The project author assumes no responsibility. Please comply with WeRead's user agreement and applicable laws and regulations.\n\nhttps://github.com/qiuyukang/weread.koplugin"), self.version),
+                    text = T(_("WeRead Plugin v%1\n\nDisclaimer: This project is for personal learning and technical research only, not for commercial use. All consequences arising from the use of this project (including but not limited to account bans, data loss, etc.) are borne by the user. The project author assumes no responsibility. Please comply with WeRead's user agreement and applicable laws and regulations.\n\nhttps://github.com/finlater/weread.koplugin"), self.version),
                 })
             end,
         },

--- a/ui/thought_popup.lua
+++ b/ui/thought_popup.lua
@@ -7,7 +7,7 @@
     3. 左右滑动关闭弹窗
     4. 性能优化：regular weight 字体、CSS 缓存、MuPDF 预热
 
-@module lib.thought_popup
+@module ui.thought_popup
 --]]--
 
 local BD = require("ui/bidi")


### PR DESCRIPTION
## 变更说明 / Summary

请说明这个 PR 解决了什么问题，或者新增了什么特性。

Describe what this PR fixes or adds.

## 类型 / Type

- [ ] Bugfix / Bug 修复
- [ ] Feature / 新功能
- [ ] Refactor / 重构
- [ ] Documentation / 文档
- [ ] Other / 其他

## Bugfix 要求 / Bugfix requirements

如果这是 bugfix，请至少提供以下其中一项：

- 关联 issue：`Fixes #123`
- 修复前的清晰复现步骤

If this is a bugfix, provide at least one of:

- Linked issue: `Fixes #123`
- Clear reproduction steps before the fix

## Feature 要求 / Feature requirements

如果这是新增特性，请说明：

- 新增了什么能力
- 典型使用场景
- 如果涉及 UI、菜单、弹窗、排版或交互，请提供截图或录屏

If this adds a feature, describe:

- What capability was added
- Typical use case
- Screenshots or screen recording if it changes UI, menus, dialogs, layout, or interaction

## 测试 / Testing

请说明你如何验证这个 PR。

Describe how you tested this PR.

- [ ] 已在 KOReader 中手动测试 / Manually tested in KOReader
- [ ] 已运行相关脚本或检查 / Ran relevant scripts or checks
- [ ] 不适用，仅文档或注释变更 / Not applicable, docs/comments only

测试说明 / Test details:

```text

```

## 非公开 WeRead API / Non-public WeRead APIs

如果本 PR 新增或修改任何非公开 WeRead Web API，必须同时在 `scripts/` 中提交一个可独立运行、可复现该接口行为的 Python 验证脚本。仅描述验证方式不能替代脚本。脚本不得打印或保存真实 API Key、Cookie、Token、完整 cURL 或账号标识。

If this PR adds or changes any non-public WeRead Web API, it must include a standalone reproducible Python verification script under `scripts/`. Describing the validation is not a substitute for the script. The script must not print or persist real API keys, cookies, tokens, full cURL commands, or account identifiers.

- [ ] 不涉及非公开 WeRead API / Does not touch non-public WeRead APIs
- [ ] 已新增或更新可复现的 Python 验证脚本 / Added or updated a reproducible Python verification script

脚本路径 / Script path:

```text
scripts/
```

复现命令与脱敏结果 / Reproduction command and sanitized result:

```text

```

## 截图 / Screenshots

如果涉及 UI 或交互变更，请在这里添加截图或录屏。

If this changes UI or interaction, add screenshots or a screen recording here.

## Checklist

- [ ] 我已经说明这个 PR 解决的问题或新增的特性。 / I described the problem fixed or feature added.
- [ ] 如果是 bugfix，我已经提供复现步骤或关联 issue。 / For a bugfix, I provided reproduction steps or linked an issue.
- [ ] 如果是新增 UI/交互特性，我已经提供截图或录屏。 / For a new UI/interaction feature, I added screenshots or a screen recording.
- [ ] 我没有提交 KOReader `settings/weread.lua`、API key、cookie、token、`x-wrpa-*` 或私人书籍内容。 / I did not commit KOReader `settings/weread.lua`, API keys, cookies, tokens, `x-wrpa-*`, or private book content.
- [ ] 如果修改了用户可见文本，我已经更新 `lib/i18n.lua`。 / If I changed user-facing text, I updated `lib/i18n.lua`.
- [ ] 如果修改了菜单结构，我已经同步更新 README 菜单结构。 / If I changed menu structure, I updated the README menu tree.
- [ ] 如果涉及非公开 WeRead Web API，我已经在 `scripts/` 中提交可独立运行、可复现的 Python 验证脚本，并填写了复现命令和脱敏结果。 / If this touches non-public WeRead Web APIs, I included a standalone reproducible Python verification script under `scripts/` and documented the command and sanitized result.
