### PR TITLE
feat(downloader): add per-chapter cache, retry on failure, and abort on chapter error

### DIFF
--- a/weread/lib/downloader.lua
+++ b/weread/lib/downloader.lua
@@ -25,7 +25,19 @@ local I18n = require("weread.lib.i18n")
 local Thoughts = require("weread.lib.thoughts")
 local WeRead = require("weread.lib.protocol")
 
+local _, json = pcall(require, "json")
+if not json then
+    _, json = pcall(require, "rapidjson")
+end
+if not json then
+    logger.warn("[WeRead]", "json module not available, chapter cache will be degraded")
+end
+
 local LOG_MODULE = "[WeRead]"
+
+-- Chapter download retry parameters (matching original api.lua).
+local CHAPTER_MAX_RETRIES = 5
+local CHAPTER_MAX_RETRY_INTERVAL = 10 -- seconds
 
 local function _(text)
     return I18n.tr(text)
@@ -65,6 +77,207 @@ local function allowOsStandby()
     if Device:isCervantes() or Device:isKobo() then
         PluginShare.pause_auto_suspend = false
     end
+-- ---------------------------------------------------------------------------
+-- Chapter cache (per-chapter xhtml + assets persisted to disk)
+-- ---------------------------------------------------------------------------
+
+local function filename_safe(value)
+    value = tostring(value or ""):gsub("[%z%c/\\:%*%?\"<>|]", "_")
+    value = value:gsub("^%s+", ""):gsub("%s+$", "")
+    if value == "" then return "_" end
+    return value
+end
+
+local function chapter_cache_root(settings, book)
+    local book_id = book.book_id or book.bookId
+    local dir = Content.book_resolved_dir(settings, book_id, book)
+    return dir .. "/chapters"
+end
+
+local function chapter_xhtml_path(settings, book, chapter_uid)
+    return chapter_cache_root(settings, book) .. "/" .. tostring(chapter_uid) .. ".xhtml"
+end
+
+local function chapter_assets_meta_path(settings, book, chapter_uid)
+    return chapter_cache_root(settings, book) .. "/" .. tostring(chapter_uid) .. ".assets.json"
+end
+
+local function asset_file_path(settings, book, href)
+    return chapter_cache_root(settings, book) .. "/assets/" .. filename_safe(href)
+end
+
+local function book_state_path(settings, book)
+    return chapter_cache_root(settings, book) .. "/_state.json"
+end
+
+local function ensure_dir(path)
+    os.execute("mkdir -p " .. string.format("%q", path))
+end
+
+local function read_file(path)
+    local file, err = io.open(path, "rb")
+    if not file then
+        return nil, err
+    end
+    local data = file:read("*a")
+    file:close()
+    return data
+end
+
+local function write_file(path, data)
+    local file, err = io.open(path, "wb")
+    if not file then
+        return false, err
+    end
+    file:write(data)
+    file:close()
+    return true
+end
+
+--- Compute a fingerprint of download-affecting settings so cached chapters
+--- are invalidated when the user changes relevant options.
+local function compute_settings_fingerprint(settings)
+    local cache = settings:get("cache", {})
+    -- Settings that affect chapter content; changing any of these requires
+    -- re-downloading all chapters.
+    return string.format("th=%s_img=%s",
+        tostring(cache.download_underlines_and_thoughts == true),
+        tostring(cache.download_book_images == true))
+end
+
+--- Remove all cached chapter data for a book.
+local function clear_chapter_cache(settings, book)
+    local root = chapter_cache_root(settings, book)
+    if root and root ~= "" and root ~= "/" then
+        os.execute("rm -rf " .. string.format("%q", root))
+        logger.info(LOG_MODULE, "chapter cache cleared (settings changed):", root)
+    end
+end
+
+--- Persist dl.state fields that accumulate across chapters so cached
+--- chapters can reconstruct the annotation CSS state.
+local function save_book_state(settings, book, state)
+    if not json then return end
+    local root = chapter_cache_root(settings, book)
+    ensure_dir(root)
+    local payload = {
+        css = state.css or "",
+        annotation_css_seen = state.annotation_css_seen or {},
+        settings_fingerprint = compute_settings_fingerprint(settings),
+    }
+    local ok, encoded = pcall(function() return json.encode(payload) end)
+    if ok then
+        write_file(book_state_path(settings, book), encoded)
+    end
+end
+
+--- Load previously persisted dl.state fields (annotation CSS accumulator).
+-- Returns nil if the saved fingerprint does not match current settings
+-- (stale cache after user changed download options).
+local function load_book_state(settings, book)
+    if not json then return nil end
+    local raw = read_file(book_state_path(settings, book))
+    if not raw then return nil end
+    local ok, payload = pcall(function() return json.decode(raw) end)
+    if not ok or type(payload) ~= "table" then
+        return nil
+    end
+    local current_fp = compute_settings_fingerprint(settings)
+    if payload.settings_fingerprint and payload.settings_fingerprint ~= current_fp then
+        logger.info(LOG_MODULE, "chapter cache settings fingerprint mismatch, discarding:",
+            "saved=", payload.settings_fingerprint, "current=", current_fp)
+        clear_chapter_cache(settings, book)
+        return nil
+    end
+    return {
+        css = payload.css or "",
+        annotation_css_seen = payload.annotation_css_seen or {},
+    }
+end
+
+--- Persist a fully-processed chapter so subsequent downloads can skip it.
+-- Writes:  chapters/<uid>.xhtml   (final processed xhtml)
+--          chapters/<uid>.assets.json  ([{href, media_type}, ...])
+--          chapters/assets/<safe_href>  (binary asset data)
+local function save_chapter_cache(settings, book, chapter_uid, xhtml, chapter_assets)
+    local root = chapter_cache_root(settings, book)
+    ensure_dir(root)
+    ensure_dir(root .. "/assets")
+
+    -- XHTML
+    local xhtml_path = chapter_xhtml_path(settings, book, chapter_uid)
+    if not write_file(xhtml_path, xhtml) then
+        logger.warn(LOG_MODULE, "failed to write chapter xhtml cache:", xhtml_path)
+        return false
+    end
+
+    -- Asset metadata + data
+    if chapter_assets and #chapter_assets > 0 then
+        local meta = {}
+        for _, asset in ipairs(chapter_assets) do
+            table.insert(meta, { href = asset.href, media_type = asset.media_type })
+            local apath = asset_file_path(settings, book, asset.href)
+            write_file(apath, asset.data)
+        end
+        if json then
+            local ok, encoded = pcall(function() return json.encode(meta) end)
+            if ok then
+                write_file(chapter_assets_meta_path(settings, book, chapter_uid), encoded)
+            else
+                logger.warn(LOG_MODULE, "failed to encode chapter asset meta:", chapter_uid)
+            end
+        end
+    end
+
+    logger.info(LOG_MODULE, "chapter cache saved:", "chapter_uid=", tostring(chapter_uid))
+    return true
+end
+
+--- Load a cached chapter back into memory.
+-- @return xhtml (string|nil), assets (table|nil)
+local function load_chapter_cache(settings, book, chapter_uid)
+    local xhtml_path = chapter_xhtml_path(settings, book, chapter_uid)
+    local xhtml = read_file(xhtml_path)
+    if not xhtml then
+        return nil
+    end
+
+    local assets = {}
+    local meta_path = chapter_assets_meta_path(settings, book, chapter_uid)
+    local meta_raw = read_file(meta_path)
+    if meta_raw and json then
+        local ok, meta = pcall(function() return json.decode(meta_raw) end)
+        if ok and type(meta) == "table" then
+            for _, entry in ipairs(meta) do
+                local apath = asset_file_path(settings, book, entry.href)
+                local data = read_file(apath)
+                if data then
+                    table.insert(assets, {
+                        href = entry.href,
+                        data = data,
+                        media_type = entry.media_type,
+                    })
+                end
+            end
+        end
+    end
+
+    logger.info(LOG_MODULE, "chapter cache hit:", "chapter_uid=", tostring(chapter_uid),
+        "xhtml_bytes=", tostring(#xhtml), "assets=", tostring(#assets))
+    return xhtml, assets
+end
+
+--- Check whether a chapter is cached on disk.
+local function chapter_cache_exists(settings, book, chapter_uid)
+    local xhtml_path = chapter_xhtml_path(settings, book, chapter_uid)
+    local file = io.open(xhtml_path, "rb")
+    if file then
+        file:close()
+        return true
+    end
+    return false
+end
+
 end
 
 local Downloader = {}


### PR DESCRIPTION
## 变更说明 / Summary

1. 为章节下载添加重试与断点续传机制
2. 章节下载重试失败后弹出错误而不是继续下载下一章节，防止出现漏章问题

## 类型 / Type

- [ ] Bugfix / Bug 修复
- [x] Feature / 新功能
- [ ] Refactor / 重构
- [ ] Documentation / 文档
- [ ] Other / 其他

## Feature 要求 / Feature requirements

增加章节下载缓存用于断点续传，下载失败时增加指数退避重试
避免在网络不佳时下载书籍出现漏章问题

## 测试 / Testing

1. 找一本书，点击下载全书，在下载章节时断开网络，此时应进行重试
2. 重试成功后，继续下载两章，点击取消下载，下载流程取消
3. 再次点击下载全书，已下载过的章节应会从缓存中加载，并继续下载其他后续章节
4. 全书下载完成后检查目录及正文，应不存在章节错漏问题

- [x] 已在 KOReader 中手动测试 / Manually tested in KOReader
- [ ] 已运行相关脚本或检查 / Ran relevant scripts or checks
- [ ] 不适用，仅文档或注释变更 / Not applicable, docs/comments only

## Checklist

- [x] 我已经说明这个 PR 解决的问题或新增的特性。 / I described the problem fixed or feature added.
- [ ] 如果是 bugfix，我已经提供复现步骤或关联 issue。 / For a bugfix, I provided reproduction steps or linked an issue.
- [ ] 如果是新增 UI/交互特性，我已经提供截图或录屏。 / For a new UI/interaction feature, I added screenshots or a screen recording.
- [x] 我没有提交 KOReader `settings/weread.lua`、API key、cookie、token、`x-wrpa-*` 或私人书籍内容。 / I did not commit KOReader `settings/weread.lua`, API keys, cookies, tokens, `x-wrpa-*`, or private book content.
- [x] 如果修改了用户可见文本，我已经更新 `lib/i18n.lua`。 / If I changed user-facing text, I updated `lib/i18n.lua`.
- [ ] 如果修改了菜单结构，我已经同步更新 README 菜单结构。 / If I changed menu structure, I updated the README menu tree.
- [ ] 如果涉及非公开 WeRead Web API，我已经在 `scripts/` 中提交可独立运行、可复现的 Python 验证脚本，并填写了复现命令和脱敏结果。 / If this touches non-public WeRead Web APIs, I included a standalone reproducible Python verification script under `scripts/` and documented the command and sanitized result.
