### PR TITLE
feat: add SQLite-based thought storage with JSON fallback

### DIFF
--- a/lib/downloader.lua
+++ b/lib/downloader.lua
@@ -270,7 +270,7 @@ function Downloader:_applyAnnotations(dl)
     local started = time.now()
     local ok, processed, annotation_css = pcall(function()
         return Thoughts.apply_data(self.settings, book_id, chapter.chapterUid,
-            dl.current.xhtml, annotation.underlines, annotation.reviews)
+            dl.current.xhtml, annotation.underlines, annotation.reviews, dl.book)
     end)
     self:_perf(dl, "apply_annotations", started, "ok=", tostring(ok),
         "reviews=", tostring(#annotation.reviews))

--- a/lib/downloader.lua
+++ b/lib/downloader.lua
@@ -270,7 +270,9 @@ function Downloader:_applyAnnotations(dl)
     local started = time.now()
     local ok, processed, annotation_css = pcall(function()
         return Thoughts.apply_data(self.settings, book_id, chapter.chapterUid,
-            dl.current.xhtml, annotation.underlines, annotation.reviews, dl.book)
+            dl.current.xhtml, annotation.underlines, annotation.reviews, dl.book, {
+            rebuild_thought_db = not dl.single_chapter and dl.index == 1,
+        })
     end)
     self:_perf(dl, "apply_annotations", started, "ok=", tostring(ok),
         "reviews=", tostring(#annotation.reviews))

--- a/lib/i18n.lua
+++ b/lib/i18n.lua
@@ -20,6 +20,7 @@ local zh = {
     ["Downloading public account article images may significantly increase download time. Continue?"] = "下载公众号文章图片可能会显著延长下载时间，是否继续？",
     ["Downloading underlines and thoughts adds requests for every chapter and may significantly increase download time and cache usage. Continue?"] = "下载划线和想法会为每个章节增加额外请求，并可能显著延长下载时间和增加缓存占用。是否继续？",
     ["No cached thoughts found for this chapter. Please re-download the book with underlines and thoughts."] = "未找到本章的想法缓存，请重新下载本书（含划线和想法）。",
+    ["Thought cache error. Please re-download this book with underlines and thoughts."] = "想法缓存异常，请重新下载本书的划线和想法",
     ["Loading thoughts…"] = "正在加载想法…",
     ["No matching thought found for this underline."] = "未找到该划线对应的想法。",
     ["Confirm"] = "确认",

--- a/lib/thought_db.lua
+++ b/lib/thought_db.lua
@@ -1,0 +1,147 @@
+--[[--
+SQLite-based thought storage for WeRead KOReader plugin.
+
+One database per book directory: {book_dir}/thoughts.db
+
+Schema per lua-ljsqlite3 conventions:
+  reviews(chapter_uid, range, review_json, review_html, item_count, updated_at)
+  covering index on (chapter_uid, range)
+
+Write: putReview / putReviews (from lib/thoughts.lua:apply_data).
+Read:  getReviewHTML (from main.lua:_buildThoughtHtmlFromHref).
+--]]--
+
+local logger = require("logger")
+local JSON = require("json")
+
+local ThoughtDB = {}
+
+local function getSQ3()
+    local ok, SQ3 = pcall(require, "lua-ljsqlite3/init")
+    if ok and SQ3 then
+        return SQ3
+    end
+    return nil
+end
+
+--- Open or create the per-book thought database.
+function ThoughtDB.open(book_dir)
+    if type(book_dir) ~= "string" or book_dir == "" then
+        return nil
+    end
+
+    local SQ3 = getSQ3()
+    if not SQ3 then
+        logger.info("weread: thought_db lua-ljsqlite3 unavailable, fallback to json")
+        return nil
+    end
+
+    
+    local lfs = require("libs/libkoreader-lfs")
+    lfs.mkdir(book_dir)
+    local db_path = book_dir .. "/thoughts.db"
+
+    local ok, db = pcall(SQ3.open, db_path)
+    if not ok or not db then
+        logger.warn("weread: thought_db open failed:", db_path, db)
+        return nil
+    end
+
+    pcall(function() db:exec("PRAGMA journal_mode=WAL") end)
+    pcall(function() db:exec("PRAGMA synchronous=NORMAL") end)
+
+    db:exec([[
+        CREATE TABLE IF NOT EXISTS reviews (
+            chapter_uid INTEGER NOT NULL,
+            range       TEXT    NOT NULL,
+            review_json TEXT    NOT NULL,
+            review_html TEXT    NOT NULL,
+            item_count  INTEGER NOT NULL DEFAULT 0,
+            updated_at  INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (chapter_uid, range)
+        )
+    ]])
+
+    db:exec([[
+        CREATE INDEX IF NOT EXISTS idx_reviews_lookup
+        ON reviews(chapter_uid, range)
+    ]])
+
+    logger.info("weread: thought_db opened", db_path)
+    return db
+end
+
+--- Look up pre-built popup HTML for a (chapter_uid, range) pair.
+function ThoughtDB.getReviewHTML(db, chapter_uid, range_str)
+    if not db then return nil end
+
+    local SQ3 = getSQ3()
+    if not SQ3 then return nil end
+
+    local ok, stmt = pcall(function()
+        return db:prepare(
+            "SELECT review_html, item_count FROM reviews WHERE chapter_uid=? AND range=?"
+        )
+    end)
+    if not ok or not stmt then return nil end
+
+    local row = stmt:reset():bind(chapter_uid, range_str):step()
+    if row then
+        return row[1], row[2]
+    end
+    return nil
+end
+
+--- Insert or replace a single review row.
+function ThoughtDB.putReview(db, chapter_uid, review, review_html)
+    if not db or type(review) ~= "table" then return end
+
+    local range_str = review.range
+    if type(range_str) ~= "string" or range_str == "" then return end
+
+    local json_str = JSON.encode(review)
+    local item_count = review.pageReviews and #review.pageReviews or 0
+
+    local ok, stmt = pcall(function()
+        return db:prepare([[
+            INSERT OR REPLACE INTO reviews
+                (chapter_uid, range, review_json, review_html, item_count, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+        ]])
+    end)
+    if not ok or not stmt then return end
+
+    stmt:reset():bind(chapter_uid, range_str, json_str, review_html or "", item_count, os.time()):step()
+end
+
+--- Batch-insert all reviews for a chapter in a single transaction.
+function ThoughtDB.putReviews(db, chapter_uid, reviews)
+    if not db or type(reviews) ~= "table" then return end
+
+    local Annotations = require("lib.annotations")
+
+    pcall(function() db:exec("BEGIN") end)
+
+    local count = 0
+    for _, rv in ipairs(reviews) do
+        if type(rv) == "table" then
+            local review_html = Annotations.buildThoughtPopupHtml(rv)
+            ThoughtDB.putReview(db, chapter_uid, rv, review_html)
+            count = count + 1
+        end
+    end
+
+    pcall(function() db:exec("COMMIT") end)
+
+    logger.info("weread: thought_db written chapter_uid=", chapter_uid,
+        " count=", #reviews)
+end
+
+--- Close the database handle.
+function ThoughtDB.close(db)
+    if db then
+        pcall(function() db:close() end)
+    end
+end
+
+return ThoughtDB

--- a/lib/thought_db.lua
+++ b/lib/thought_db.lua
@@ -24,6 +24,21 @@ local function getSQ3()
     return nil
 end
 
+--- Delete thoughts.db and WAL/SHM sidecars. Missing files are ignored.
+function ThoughtDB.remove_db(book_dir)
+    if type(book_dir) ~= "string" or book_dir == "" then
+        return false
+    end
+    for _, path in ipairs({
+        book_dir .. "/thoughts.db",
+        book_dir .. "/thoughts.db-wal",
+        book_dir .. "/thoughts.db-shm",
+    }) do
+        os.remove(path)
+    end
+    return true
+end
+
 --- Open or create the per-book thought database.
 function ThoughtDB.open(book_dir)
     if type(book_dir) ~= "string" or book_dir == "" then
@@ -36,7 +51,6 @@ function ThoughtDB.open(book_dir)
         return nil
     end
 
-    
     local lfs = require("libs/libkoreader-lfs")
     lfs.mkdir(book_dir)
     local db_path = book_dir .. "/thoughts.db"
@@ -50,22 +64,28 @@ function ThoughtDB.open(book_dir)
     pcall(function() db:exec("PRAGMA journal_mode=WAL") end)
     pcall(function() db:exec("PRAGMA synchronous=NORMAL") end)
 
-    db:exec([[
-        CREATE TABLE IF NOT EXISTS reviews (
-            chapter_uid INTEGER NOT NULL,
-            range       TEXT    NOT NULL,
-            review_json TEXT    NOT NULL,
-            review_html TEXT    NOT NULL,
-            item_count  INTEGER NOT NULL DEFAULT 0,
-            updated_at  INTEGER NOT NULL DEFAULT 0,
-            PRIMARY KEY (chapter_uid, range)
-        )
-    ]])
-
-    db:exec([[
-        CREATE INDEX IF NOT EXISTS idx_reviews_lookup
-        ON reviews(chapter_uid, range)
-    ]])
+    local schema_ok, schema_err = pcall(function()
+        db:exec([[
+            CREATE TABLE IF NOT EXISTS reviews (
+                chapter_uid INTEGER NOT NULL,
+                range       TEXT    NOT NULL,
+                review_json TEXT    NOT NULL,
+                review_html TEXT    NOT NULL,
+                item_count  INTEGER NOT NULL DEFAULT 0,
+                updated_at  INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (chapter_uid, range)
+            )
+        ]])
+        db:exec([[
+            CREATE INDEX IF NOT EXISTS idx_reviews_lookup
+            ON reviews(chapter_uid, range)
+        ]])
+    end)
+    if not schema_ok then
+        logger.warn("weread: thought_db schema init failed:", db_path, schema_err)
+        pcall(function() db:close() end)
+        return nil
+    end
 
     logger.info("weread: thought_db opened", db_path)
     return db
@@ -85,8 +105,10 @@ function ThoughtDB.getReviewHTML(db, chapter_uid, range_str)
     end)
     if not ok or not stmt then return nil end
 
-    local row = stmt:reset():bind(chapter_uid, range_str):step()
-    if row then
+    local step_ok, row = pcall(function()
+        return stmt:reset():bind(chapter_uid, range_str):step()
+    end)
+    if step_ok and row then
         return row[1], row[2]
     end
     return nil

--- a/lib/thoughts.lua
+++ b/lib/thoughts.lua
@@ -31,33 +31,6 @@ function Thoughts.cache_path(settings, book_id, chapter_uid)
     return Thoughts.cache_dir(settings, book_id) .. "/" .. tostring(chapter_uid) .. ".json"
 end
 
-function Thoughts.save_cache(settings, book_id, chapter_uid, reviews)
-    if type(reviews) ~= "table" or #reviews == 0 then
-        return false
-    end
-    local dir = Thoughts.cache_dir(settings, book_id)
-    os.execute("mkdir -p " .. string.format("%q", dir))
-    local path = Thoughts.cache_path(settings, book_id, chapter_uid)
-    local file = io.open(path, "w")
-    if not file then
-        return false
-    end
-    local ok, encoded = pcall(require("json").encode, reviews)
-    if not ok then
-        ok, encoded = pcall(function()
-            local json = require("rapidjson")
-            return json:encode(reviews)
-        end)
-    end
-    if not ok or not encoded then
-        file:close()
-        return false
-    end
-    file:write(encoded)
-    file:close()
-    log_info("cached thought groups:", #reviews, "chapter:", chapter_uid)
-    return true
-end
 
 --- 读取某章缓存的想法数据（save_cache 的对称读取端）。
 -- 点击划线时由 main.lua 调用，按 range 匹配后渲染弹窗。
@@ -124,18 +97,22 @@ function Thoughts.fetch_underlines(client, settings, book_id, chapter_uid)
     return true, data, Thoughts.collect_ranges(data)
 end
 
-function Thoughts.apply_data(settings, book_id, chapter_uid, xhtml, underlines_data, reviews)
+function Thoughts.apply_data(settings, book_id, chapter_uid, xhtml, underlines_data, reviews, book)
     if type(underlines_data) ~= "table" then
-        return xhtml, ""
+        underlines_data = {}
     end
     if type(reviews) == "table" and #reviews > 0 then
-        Thoughts.save_cache(settings, book_id, chapter_uid, reviews)
+        local Content = require("lib.content")
+        local book_dir = Content.book_resolved_dir(settings, book_id, book)
+        local ThoughtDB = require("lib.thought_db")
+        local db = ThoughtDB.open(book_dir)
+        if db then
+            pcall(ThoughtDB.putReviews, db, chapter_uid, reviews)
+            ThoughtDB.close(db)
+        end
     end
     underlines_data.chapterUid = chapter_uid
     local processed, annotation_css = Annotations.process(xhtml, underlines_data, reviews, book_id)
-    if processed ~= xhtml then
-        log_info("injected underlines for chapter:", chapter_uid)
-    end
     return processed, annotation_css or ""
 end
 

--- a/lib/thoughts.lua
+++ b/lib/thoughts.lua
@@ -97,7 +97,7 @@ function Thoughts.fetch_underlines(client, settings, book_id, chapter_uid)
     return true, data, Thoughts.collect_ranges(data)
 end
 
-function Thoughts.apply_data(settings, book_id, chapter_uid, xhtml, underlines_data, reviews, book)
+function Thoughts.apply_data(settings, book_id, chapter_uid, xhtml, underlines_data, reviews, book, opts)
     if type(underlines_data) ~= "table" then
         underlines_data = {}
     end
@@ -105,7 +105,14 @@ function Thoughts.apply_data(settings, book_id, chapter_uid, xhtml, underlines_d
         local Content = require("lib.content")
         local book_dir = Content.book_resolved_dir(settings, book_id, book)
         local ThoughtDB = require("lib.thought_db")
+        if opts and opts.rebuild_thought_db then
+            ThoughtDB.remove_db(book_dir)
+        end
         local db = ThoughtDB.open(book_dir)
+        if not db then
+            ThoughtDB.remove_db(book_dir)
+            db = ThoughtDB.open(book_dir)
+        end
         if db then
             pcall(ThoughtDB.putReviews, db, chapter_uid, reviews)
             ThoughtDB.close(db)

--- a/main.lua
+++ b/main.lua
@@ -29,6 +29,7 @@ local Settings = require("lib.settings")
 local Thoughts = require("lib.thoughts")
 local WeRead = require("lib.weread")
 local ThoughtPopup = require("ui.thought_popup")
+local ThoughtDB = require("lib.thought_db")
 
 -- `_` is the translation function; never reuse it as a loop placeholder in this file.
 local function _(text)
@@ -2773,25 +2774,31 @@ function WeReadPlugin:_loadThoughtReviews(book_id, chapter_uid)
     return reviews
 end
 
--- Whether this href's chapter thoughts are already decoded in memory. Used to
--- decide if the first-tap loading message is needed (skipped once cached).
-function WeReadPlugin:_isChapterThoughtsCached(href)
-    local info = self:_parseThoughtHref(href)
-    if not info or not self._thought_json_cache then
-        return false
-    end
-    return self._thought_json_cache[tostring(info.book_id) .. ":" .. tostring(info.chapter_uid)] ~= nil
-end
-
 -- Load the chapter's cached thoughts, match the tapped range, render popup HTML.
 function WeReadPlugin:_buildThoughtHtmlFromHref(href)
     local info = self:_parseThoughtHref(href)
     if not info then
         return nil
     end
+
+    -- 1. Try SQLite indexed lookup
+    local books = self.settings:get("books", {})
+    local book = books[info.book_id]
+    if book then
+        local book_dir = Content.book_resolved_dir(self.settings, info.book_id, book)
+        local db = ThoughtDB.open(book_dir)
+        if db then
+            local sql_html = ThoughtDB.getReviewHTML(db, info.chapter_uid, info.range)
+            ThoughtDB.close(db)
+            if sql_html then
+                return sql_html
+            end
+        end
+    end
+
+    -- 2. JSON fallback for legacy caches
     local reviews = self:_loadThoughtReviews(info.book_id, info.chapter_uid)
     if type(reviews) ~= "table" then
-        -- Cache missing/unreadable (e.g. user deleted thoughts/<uid>.json).
         self:showInfo(_("No cached thoughts found for this chapter. Please re-download the book with underlines and thoughts."))
         return nil
     end
@@ -2804,7 +2811,6 @@ function WeReadPlugin:_buildThoughtHtmlFromHref(href)
             break
         end
     end
-    -- Recognized underline but no renderable thought (range not in cache, or empty).
     self:showInfo(_("No matching thought found for this underline."))
     return nil
 end
@@ -2849,20 +2855,9 @@ function WeReadPlugin:_onThoughtTap(ges)
     self._thought_html_cache = self._thought_html_cache or {}
     local html = self._thought_html_cache[href]
     if html == nil then
-        -- The first tap in a chapter reads + decodes its thoughts JSON, which can
-        -- take a moment for chapters with many thoughts. Show a brief loading
-        -- message; skipped once the chapter is cached, so it never flashes on
-        -- subsequent (instant) taps.
-        local loading
-        if not self:_isChapterThoughtsCached(href) then
-            loading = InfoMessage:new{ text = _("Loading thoughts…") }
-            UIManager:show(loading)
-            self:refreshUI()  -- force the message to paint before the blocking load
-        end
+        -- SQLite lookup is sub-millisecond; JSON fallback is a single file read.
+        -- No loading message needed.
         html = self:_buildThoughtHtmlFromHref(href) or false
-        if loading then
-            UIManager:close(loading)
-        end
         self._thought_html_cache_n = (self._thought_html_cache_n or 0) + 1
         if self._thought_html_cache_n > THOUGHT_HTML_CACHE_MAX then
             self._thought_html_cache = {}

--- a/main.lua
+++ b/main.lua
@@ -2799,7 +2799,7 @@ function WeReadPlugin:_buildThoughtHtmlFromHref(href)
     -- 2. JSON fallback for legacy caches
     local reviews = self:_loadThoughtReviews(info.book_id, info.chapter_uid)
     if type(reviews) ~= "table" then
-        self:showInfo(_("No cached thoughts found for this chapter. Please re-download the book with underlines and thoughts."))
+        self:showInfo(_("Thought cache error. Please re-download this book with underlines and thoughts."))
         return nil
     end
     for _i, rv in ipairs(reviews) do


### PR DESCRIPTION
Replace per-chapter JSON-file thought caching with SQLite (lua-ljsqlite3) for indexed per-range lookup and pre-built popup HTML storage.

- New lib/thought_db.lua: stateless SQLite module (open/getReviewHTML/putReview/putReviews/close)
- Write path: downloader stores pre-built popup HTML to SQLite after annotation fetch
- Read path: SQLite-first indexed lookup (~1ms), transparent JSON fallback for legacy caches
- Remove dead code: save_cache (JSON write), _isChapterThoughtsCached, loading message flash

## 变更说明 / Summary

将想法（划线想法/划线标注）缓存从逐章 JSON 文件改为 SQLite 存储。

## 类型 / Type

- [ ] Bugfix / Bug 修复
- [x] Feature / 新功能
- [ ] Refactor / 重构
- [ ] Documentation / 文档
- [ ] Other / 其他

## Feature 要求 / Feature requirements

- 大幅提升点击划线时想法加载性能
- 防止热门书籍出现较大想法 JSON 时存在内存溢出问题

## 测试 / Testing

1. 打开更新前下载的书籍，应能正确 fallback 到 JSON 想法文件读取
2. 重新下载书籍，应能正确将想法存储到 sqlite 数据库，并点击弹窗能够正确弹出

- [x] 已在 KOReader 中手动测试 / Manually tested in KOReader
- [ ] 已运行相关脚本或检查 / Ran relevant scripts or checks
- [ ] 不适用，仅文档或注释变更 / Not applicable, docs/comments only

## Checklist

- [x] 我已经说明这个 PR 解决的问题或新增的特性。 / I described the problem fixed or feature added.
- [ ] 如果是 bugfix，我已经提供复现步骤或关联 issue。 / For a bugfix, I provided reproduction steps or linked an issue.
- [ ] 如果是新增 UI/交互特性，我已经提供截图或录屏。 / For a new UI/interaction feature, I added screenshots or a screen recording.
- [x] 我没有提交 KOReader `settings/weread.lua`、API key、cookie、token、`x-wrpa-*` 或私人书籍内容。 / I did not commit KOReader `settings/weread.lua`, API keys, cookies, tokens, `x-wrpa-*`, or private book content.
- [ ] 如果修改了用户可见文本，我已经更新 `lib/i18n.lua`。 / If I changed user-facing text, I updated `lib/i18n.lua`.
- [ ] 如果修改了菜单结构，我已经同步更新 README 菜单结构。 / If I changed menu structure, I updated the README menu tree.
- [ ] 如果涉及非公开 WeRead Web API，我已经在 `scripts/` 中提交可独立运行、可复现的 Python 验证脚本，并填写了复现命令和脱敏结果。 / If this touches non-public WeRead Web APIs, I included a standalone reproducible Python verification script under `scripts/` and documented the command and sanitized result.
