### PR TITLE
fix(thought): resolve TextViewer text widget across stable and develo…

### DIFF
--- a/weread/ui/thought_popup.lua
+++ b/weread/ui/thought_popup.lua
@@ -15,6 +15,7 @@ local Font = require("ui/font")
 local TextBoxWidget = require("ui/widget/textboxwidget")
 local TextViewer = require("ui/widget/textviewer")
 local UIManager = require("ui/uimanager")
+local logger = require("logger")
 
 local Annotations = require("weread.lib.annotations")
 local I18n = require("weread.lib.i18n")
@@ -94,19 +95,30 @@ local function buildDisplayPages(items, fits)
     return pages
 end
 
+-- KOReader exposes the text area as self.scroll_widget/self.box_widget only
+-- since upstream #15588 (2026-06). Released versions name it self.scroll_text_w
+-- and keep the TextBoxWidget in its .text_widget.
+function NativeThoughtPopup:_textWidgets()
+    local scroll_widget = self.scroll_widget or self.scroll_text_w
+    local box_widget = self.box_widget or (scroll_widget and scroll_widget.text_widget)
+    return scroll_widget, box_widget
+end
+
 function NativeThoughtPopup:_measureDisplayPages()
-    if not self.box_widget then
+    local _scroll_widget, box_widget = self:_textWidgets()
+    if not box_widget then
+        logger.warn("weread: thought popup text widget unavailable, keeping one item per page")
         return
     end
 
-    local visible_lines = self.box_widget:getVisLineCount()
+    local visible_lines = box_widget:getVisLineCount()
     local function fits(text)
         local measurement = TextBoxWidget:new{
             text = text,
             dialog = self,
-            face = self.box_widget.face,
-            fgcolor = self.box_widget.fgcolor,
-            width = self.box_widget.width,
+            face = box_widget.face,
+            fgcolor = box_widget.fgcolor,
+            width = box_widget.width,
             alignment = self.alignment,
             justified = self.justified,
             lang = self.lang,
@@ -123,6 +135,8 @@ function NativeThoughtPopup:_measureDisplayPages()
     local ok, pages = pcall(buildDisplayPages, self.items, fits)
     if ok and type(pages) == "table" and #pages > 0 then
         self.display_pages = pages
+    else
+        logger.warn("weread: thought popup measurement failed:", tostring(pages))
     end
 end
 
@@ -185,17 +199,20 @@ function NativeThoughtPopup:_buildButtons()
 end
 
 function NativeThoughtPopup:_replaceVisibleText()
-    if not (self.box_widget and self.box_widget.setText) then
+    local scroll_widget, box_widget = self:_textWidgets()
+    if not (box_widget and box_widget.setText) then
         return false
     end
-    self.box_widget.virtual_line_num = 1
-    if self.box_widget.text ~= self.text then
-        self.box_widget.charlist = nil
-        self.box_widget:setText(self.text)
+    box_widget.virtual_line_num = 1
+    if box_widget.text ~= self.text then
+        box_widget.charlist = nil
+        box_widget:setText(self.text)
     end
-    self.scroll_widget.text = self.text
-    if self.scroll_widget.resetScroll then
-        self.scroll_widget:resetScroll()
+    if scroll_widget then
+        scroll_widget.text = self.text
+        if scroll_widget.resetScroll then
+            scroll_widget:resetScroll()
+        end
     end
     return true
 end
@@ -269,8 +286,9 @@ function NativeThoughtPopup:changePage(delta)
     if not self:_replaceVisibleText() then
         -- Defensive fallback for an unusually old TextBoxWidget API.
         self:init(true)
-        if self.scroll_widget and self.scroll_widget.scrollToTop then
-            self.scroll_widget:scrollToTop()
+        local scroll_widget = self:_textWidgets()
+        if scroll_widget and scroll_widget.scrollToTop then
+            scroll_widget:scrollToTop()
         end
     end
 


### PR DESCRIPTION
## 变更说明

想法弹框的「短想法一页显示多条」在 2026.03 版 KOReader 上完全不生效，一页只显示一条，与 README 描述的行为不符。

根因：`weread/ui/thought_popup.lua` 的分页测量依赖 TextViewer 的 `self.box_widget`。该字段由 KOReader 上游 commit `16d9796` (2026-06-26) 引入。VI版的字段名是 `self.scroll_text_w`，TextBoxWidget 挂在它的 `.text_widget` 上。取不到字段时 `_measureDisplayPages()` 静默 return，`display_pages` 停留在 `init` 里用 `fits = function() return false end` 构造的兜底分页，即恒不合并、一条一页。

本 PR 新增 `NativeThoughtPopup:_textWidgets()`，把新旧两套字段名解析成同一对 widget（`self.scroll_widget or self.scroll_text_w`、`self.box_widget or scroll.text_widget`），并让 `_measureDisplayPages`、`_replaceVisibleText`、`changePage` 的兜底分支统一改用解析结果。

## 类型

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Bugfix 要求

Fixes #75 

修复前复现步骤：

1. 使用正式版 KOReader（2026.03 或任何早于 2026-06-26 的 release）。
2. 下载一本含划线和想法的书，勾选「下载划线和想法」。
3. 打开书籍，点击一条带星号、且对应多条想法的划线（热门想法较多的划线）。
4. 弹框底部显示 `1/N`；点「下一页」计数每次只 +1。
5. 即使想法只有一两行、弹框大片空白，也不会在同一页显示第二条。

对照：同样操作在含上游 #15588 的 nightly 上，短想法会合并显示，计数一次前进多条。

## 测试

- [x] 已在 KOReader 中手动测试
- [ ] 已运行相关脚本或检查
- [ ] 不适用，仅文档或注释变更

测试说明:

```
手动测试。
```

## 非公开 WeRead API

- [x] 不涉及非公开 WeRead API
- [ ] 已新增或更新可复现的 Python 验证脚本

脚本路径:

```text
不适用。
```

复现命令与脱敏结果:

```text
不适用。
```

## 模块结构

符合规范。仅改动 `weread/ui/thought_popup.lua`。

## 截图

修复前：
<img width="1062" height="1326" alt="image" src="https://github.com/user-attachments/assets/fe2cfa88-fb7e-422f-98ae-0e3c5643bb3c" />

修复后：
<img width="1056" height="1260" alt="image" src="https://github.com/user-attachments/assets/5e6a9520-edde-4f8b-a3d1-ddf91b538075" />


## Checklist

- [x] 我已经说明这个 PR 解决的问题或新增的特性。
- [x] 如果是 bugfix，我已经提供复现步骤或关联 issue。
- [ ] 如果是新增 UI/交互特性，我已经提供截图或录屏。（不适用：非新增特性，仅恢复既有行为；建议仍补一组前后对比图）
- [x] 我没有提交 KOReader `settings/weread.lua`、API key、cookie、token、`x-wrpa-*` 或私人书籍内容。
- [x] 新增或移动的项目 Lua 模块遵循 `weread/lib/`、`weread/ui/` 命名空间规范。
- [x] 如果修改了用户可见文本，我已经更新 `weread/lib/i18n.lua`。（不适用：无用户可见文本变更，新增的两条日志走 `logger.warn`，不经 `_()`）
- [x] 如果修改了菜单结构，我已经同步更新 README 菜单结构。（不适用：未改菜单）
- [x] 如果涉及非公开 WeRead Web API，我已经在 `scripts/` 中提交可独立运行、可复现的 Python 验证脚本，并填写了复现命令和脱敏结果。（不适用）