### PR TITLE
fix: render book footnotes in-page instead of default-off popup

### DIFF
--- a/weread/lib/footnotes.lua
+++ b/weread/lib/footnotes.lua
@@ -12,11 +12,13 @@ Footnotes.FOOTNOTES_CSS = [[
 .wr-fn-ref{font-size:0.75em;vertical-align:super;line-height:0;white-space:nowrap;}
 .wr-fn-ref a{-cr-hint:noteref;position:relative;text-decoration:none;color:#0366d6;}
 .wr-fn-ref a::after{content:"";position:absolute;top:-0.5em;right:-0.3em;bottom:-0.5em;left:-0.3em;}
-/* Do not use display:none here: CREngine then loses each aside's rendered
- * boundary and its popup range can expand across adjacent footnotes. Keep a
- * zero-height block for range detection; popup extraction ignores book CSS. */
-aside.wr-book-footnote{-cr-hint:footnote;display:block!important;visibility:hidden;height:0!important;max-height:0!important;overflow:hidden!important;margin:0!important;padding:0!important;border:0!important;font-size:0!important;line-height:0!important;text-indent:0!important;}
-aside.wr-book-footnote *{margin:0!important;padding:0!important;font-size:0!important;line-height:0!important;}
+/* Render each generated note at the bottom of the page that references it,
+ * like KOReader's built-in "In-page EPUB footnotes" tweak (ON by default).
+ * Must NOT hide the aside: the old `-cr-hint: footnote` + hidden block relied on
+ * the footnote *popup* (`footnote_link_in_popup`), which is OFF by default, so
+ * the text stayed invisible and tapping the marker followed the #id link to the
+ * hidden aside, jumping the page. `footnote-inpage` works with default settings. */
+aside.wr-book-footnote{-cr-hint:footnote-inpage;font-size:0.85em;margin:0!important;}
 div.wr-footnotes{margin:0;padding:0;border:0;}
 div.wr-footnotes>hr{display:none;}
 .wr-fn-num{font-weight:bold;margin-right:0.3em;text-decoration:none;color:inherit;}


### PR DESCRIPTION
Fixes #89 

## 变更说明

修复下载书籍中的脚注在 KOReader 默认设置下无法显示、且点击脚注标记会跳到其它页面的问题。

`weread/lib/footnotes.lua` 生成的脚注 `<aside>` 使用 `-cr-hint: footnote` 并用 `visibility:hidden; height:0; font-size:0` 隐藏正文，依赖 KOReader 的**脚注弹窗**功能（`footnote_link_in_popup`）。但该功能**默认关闭**，而默认**开启**的是「页内脚注」(`footnote-inpage_epub`)。于是在默认设置下：

- 弹窗不触发 + 正文被隐藏 → 注释看不到；
- 点击标记只是跟随内部链接 `#wrfn-…` 跳到章节末尾那个隐藏的 `<aside>` → 页面跳走。

本 PR 改用 `-cr-hint: footnote-inpage` 并去掉隐藏 CSS，让脚注按 KOReader 默认行为渲染在引用页底部，开箱即用。仅影响插件生成的 `.wr-book-footnote`，不涉及原生阅读的其它书籍。

## 类型

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Bugfix 要求

复现步骤（KOReader 默认设置，不改任何脚注相关开关）：

1. 用插件下载一本正文含脚注的书（例如《真正的归宿：与米歇尔·波尔特的对谈》）。
2. 在 KOReader 中打开该书。
3. 翻到带脚注标记（如 `[1]`）的段落，点击标记。

- 预期：显示该脚注的注释内容。
- 实际：注释不显示，页面随机跳到其它位置。

## 测试

- [x] 已在 KOReader 中手动测试
- [ ] 已运行 `bash scripts/run_lua_specs.sh`
- [ ] 已运行 `bash scripts/check_lua_namespace.sh`
- [ ] 已运行 `luacheck main.lua _meta.lua weread spec`
- [ ] 如涉及插件加载/KOReader 兼容性，已运行或触发 `KOReader integration`
- [ ] 不适用，仅文档或注释变更

测试说明:

```text
本次改动只修改了 footnotes.lua 中 FOOTNOTES_CSS 这个 CSS 常量字符串，
未改动任何 Lua 控制流/函数逻辑，生成的脚注 HTML 结构（aside + noteref）不变。
脚注的最终渲染由 KOReader/crengine 完成，无法用单元测试断言，故采用实机手动验证：

- 在实体设备上、KOReader 默认设置下重新下载并打开含脚注的书。
- 改前：脚注不显示，点击标记页面跳走。
- 改后：脚注渲染在引用页底部，点击标记不再跳页。

已下载的旧书需重新下载才能生效（旧 CSS 已写入各书的 style.css）。
```

## 非公开 WeRead API

- [x] 不涉及非公开 WeRead API
- [ ] 已新增或更新可复现的 Python 验证脚本

脚本路径:

```text
不适用
```

复现命令与脱敏结果:

```text
不适用
```

## 模块结构

- 未新增或移动任何项目 Lua 模块，仅修改现有 `weread/lib/footnotes.lua`，符合命名空间规范。

## 截图



https://github.com/user-attachments/assets/7188f981-e1a7-49e9-9985-02e86dfa3a63

<img width="3072" height="4096" alt="修复后效果" src="https://github.com/user-attachments/assets/f5a00eff-66c5-433b-a304-070d29bbad20" />

## Checklist

- [x] 我已经说明这个 PR 解决的问题或新增的特性。
- [x] 如果是 bugfix，我已经提供复现步骤或关联 issue。
- [x] 如果是新增 UI/交互特性，我已经提供截图或录屏。<!-- 视觉变更，补上截图后勾选 -->
- [x] 我没有提交 KOReader `settings/weread.lua`、API key、cookie、token、`x-wrpa-*` 或私人书籍内容。
- [x] 新增或移动的项目 Lua 模块遵循 `weread/lib/`、`weread/ui/` 命名空间规范。
- [x] 新增或修复的逻辑包含对应回归测试；若无法自动化，已在测试说明中解释原因。
- [x] 如果修改了用户可见文本，我已经更新 `weread/lib/i18n.lua`。<!-- 本 PR 未改动用户可见文本 -->
- [x] 如果修改了菜单结构，我已经同步更新 README 菜单结构。<!-- 本 PR 未改动菜单 -->
- [x] 如果涉及非公开 WeRead Web API，我已经在 `scripts/` 中提交可独立运行、可复现的 Python 验证脚本，并填写了复现命令和脱敏结果。<!-- 本 PR 不涉及 -->