### PR TITLE
thought popup: wrap long abstract titles

### DIFF
--- a/weread/ui/thought_popup.lua
+++ b/weread/ui/thought_popup.lua
@@ -151,7 +151,7 @@ function NativeThoughtPopup:_updatePage()
     local abstract = self.items[1] and self.items[1].abstract
     if type(abstract) == "string" and abstract ~= "" then
         -- Let TitleBar use its exact available width (including the close icon)
-        -- and apply its native right-edge ellipsis.
+        -- and wrap long abstracts onto multiple lines (title_multilines).
         self.title = abstract:gsub("%s+", " ")
     else
         self.title = _("Thoughts")
@@ -253,6 +253,9 @@ function NativeThoughtPopup:init(reinit)
     self.add_default_buttons = false
     self.text_type = "general"
     self.alignment = "left"
+    -- wrap long abstract titles instead of truncating
+    self.title_multilines = true
+    self.title_face = Font:getFace("x_smalltfont", 18)
     self.auto_para_direction = true
     self.buttons_table = self:_buildButtons()
     self:_updatePage()


### PR DESCRIPTION
## 变更说明

修复想法弹窗中划线原文显示不全的问题：划线原文被设为弹窗标题，而 KOReader 的 `TitleBar` 默认单行显示并在右边界截断，长划线只能看到第一行。本 PR 启用 `title_multilines` 让标题自动折行，并略微调小标题字号，减少多行标题对正文空间的挤占。

## 类型

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Bugfix 要求

复现步骤：

1. 在微信读书中对一段跨多行的文字划线并写下想法；
2. 重新下载带划线和想法的书籍；
3. 在 KOReader 中点击该划线打开想法弹窗，标题栏中的划线原文只显示第一行，其余被省略号截断。

## Feature 要求

不适用（本 PR 为 Bugfix）。

## 测试

- [x] 已在 KOReader 中手动测试
- [x] 已运行 `bash scripts/run_lua_specs.sh`
- [x] 已运行 `bash scripts/check_lua_namespace.sh`
- [x] 已运行 `luacheck main.lua _meta.lua weread spec`
- [ ] 如涉及插件加载/KOReader 兼容性，已运行或触发 `KOReader integration`
- [ ] 不适用，仅文档或注释变更

测试说明:

```text
- 已在 KOReader 真机手动测试：长划线原文在标题栏多行完整显示，翻页、正文分页与划线高亮正常。
```

## 非公开 WeRead API

如果本 PR 新增或修改任何非公开 WeRead Web API，必须同时在 `scripts/` 中提交一个可独立运行、可复现该接口行为的 Python 验证脚本。仅描述验证方式不能替代脚本。脚本不得打印或保存真实 API Key、Cookie、Token、完整 cURL 或账号标识。

- [x] 不涉及非公开 WeRead API
- [ ] 已新增或更新可复现的 Python 验证脚本

脚本路径:

```text
scripts/
```

复现命令与脱敏结果:

```text
（不适用，本 PR 不涉及非公开 WeRead API）
```

## 模块结构

本 PR 未新增或移动任何 Lua 模块。

## 截图
<img width="1072" height="1448" alt="Reader_路边野餐 - full epub_p266_2026-08-03_214755" src="https://github.com/user-attachments/assets/2c79cbd9-26ad-4593-93c4-26fc2518ea86" />


暂未提供截图；如维护者需要，可后续补充 KOReader 弹窗显示效果截图。

## Checklist

- [x] 我已经说明这个 PR 解决的问题或新增的特性。
- [x] 如果是 bugfix，我已经提供复现步骤或关联 issue。
- [x] 如果是新增 UI/交互特性，我已经提供截图或录屏。
- [x] 我没有提交 KOReader `settings/weread.lua`、API key、cookie、token、`x-wrpa-*` 或私人书籍内容。
- [x] 新增或移动的项目 Lua 模块遵循 `weread/lib/`、`weread/ui/` 命名空间规范。
- [x] 新增或修复的逻辑包含对应回归测试；若无法自动化，已在测试说明中解释原因。
- [ ] 如果修改了用户可见文本，我已经更新 `weread/lib/i18n.lua`。
- [ ] 如果修改了菜单结构，我已经同步更新 README 菜单结构。
- [ ] 如果涉及非公开 WeRead Web API，我已经在 `scripts/` 中提交可独立运行、可复现的 Python 验证脚本，并填写了复现命令和脱敏结果。
