### PR TITLE
fix: keep thought star markers visible at underline end

### DIFF
--- a/spec/content_annotations_spec.lua
+++ b/spec/content_annotations_spec.lua
@@ -48,6 +48,16 @@ expect(thought_html:find("wr%-thought%-link") ~= nil
 expect(thought_html:find('id="wrthought%-book_2%-chapter_1%-3%-8"') ~= nil,
     "thought anchor id was not sanitized")
 
+local trailing_whitespace = Annotations.injectUnderlines("<p>abc</p>\n  ", {
+    { range = "3-12" },
+}, { ["3-12"] = true }, "chapter/11", "book")
+expect(trailing_whitespace:find('<span class="wr%-star">%*</span>', 1) ~= nil,
+    "thought star survives when range ends with whitespace")
+local star_pos = trailing_whitespace:find('<span class="wr%-star">%*</span>', 1)
+local p_close_pos = trailing_whitespace:find("</p>", 1, true)
+expect(star_pos ~= nil and p_close_pos ~= nil and star_pos > p_close_pos,
+    "thought star is appended after trailing whitespace")
+
 local unchanged = Annotations.injectUnderlines("<p>safe</p>", {
     { range = "bad" },
     { range = "999-1000" },
@@ -63,6 +73,8 @@ local annotated, css = Annotations.process("<p>hello</p>", {
 expect(annotated ~= "<p>hello</p>", "annotation process did not change HTML")
 expect(css:find(".wr%-underline") and css:find(".wr%-thought%-link"),
     "annotation CSS did not include underline and thought styles")
+expect(css:find('wr%-star::before{content:"\\2060";}', 1) ~= nil,
+    "thought star CSS includes word joiner glue")
 
 local xhtml = Content.txt_to_xhtml("first & <tag>\r\n\r\nsecond")
 expect(xhtml:find("<p>first &amp; &lt;tag&gt;</p>", 1, true),

--- a/weread/lib/annotations.lua
+++ b/weread/lib/annotations.lua
@@ -18,9 +18,12 @@ Annotations.UNDERLINE_CSS = [[
 ]]
 
 -- 想法标记（星号）CSS 样式 — 浅色、右上角、小字号
+-- ::before 插入 U+2060 WORD JOINER，避免 CREngine/libunibreak
+-- 在 CJK 字符与 "*" 之间断行导致星号落到行首（KOReader 官方推荐的 glue 写法）。
 Annotations.THOUGHT_CSS = [[
 .wr-thought-link{text-decoration:none;color:inherit;}
 .wr-star{font-size:0.6em;vertical-align:super;line-height:0;color:#aaa;margin-left:1px;}
+.wr-star::before{content:"\2060";}
 ]]
 
 --- 去除字符串开头的 UTF-8 BOM（\ufeff）。
@@ -368,10 +371,11 @@ function Annotations.injectUnderlines(html, underlines, thought_reviews, chapter
             local underline_close = '</span>'
             local underline_close_with_ref = '<span class="wr-star">*</span></span>'
 
-            -- 星号注入到最后一个 underline span 末尾
+            local star_appended = false
             local last_idx = #wrapped
             if wrapped[last_idx] == underline_close then
                 wrapped[last_idx] = underline_close_with_ref
+                star_appended = true
             end
 
             -- 内部锚点（非 noteref）：去掉 epub:type="noteref" 避免 crengine 走专用
@@ -399,6 +403,13 @@ function Annotations.injectUnderlines(html, underlines, thought_reviews, chapter
                 else
                     with_links[#with_links + 1] = item
                 end
+            end
+            if not star_appended then
+                -- 末尾是纯空白段（wrapTextSegments 不包裹空白）：
+                -- 星标追加在 range 末尾（下划线 span 外），保证想法标记不丢失
+                with_links[#with_links + 1] = first_link and open_a_with_id or open_a
+                with_links[#with_links + 1] = '<span class="wr-star">*</span>'
+                with_links[#with_links + 1] = '</a>'
             end
             wrapped = with_links
         end


### PR DESCRIPTION
When a highlight range ends with whitespace that wrapTextSegments skips, append the star link after the range instead of relying on the last underline span close tag. Add U+2060 word joiner glue in CSS so CREngine does not break CJK text away from the star onto the next line.

## 变更说明

修复带想法的划线在 EPUB 注入后，想法星标（*）偶发不显示，或 换行后单独落到下一行行首 的问题。

## 类型

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Bugfix 要求

 修复前复现步骤：

 1. 下载带想法的章节（开启「下载正文、划线和想法」）。
 2. 找一条划线 range 覆盖段落末尾空白（常见于 range 延伸到 </p> 后的换行/空格），或在 CJK 文本行尾附近带想法的划线。
 3. 在 KOReader 中打开该章节，观察划线末尾：
   - 问题 A：有下划线但看不到 * 星标（无法识别该划线有想法）。
   - 问题 B：星标出现在下一行行首，而非紧贴划线文本右上角。

 修复后预期：

 - 每条有想法的划线均显示星标。
 - 星标紧跟划线文本，不因换行单独落到行首。

## 测试

- [x] 已在 KOReader 中手动测试
- [x] 已运行 `bash scripts/run_lua_specs.sh`
- [x] 已运行 `bash scripts/check_lua_namespace.sh`
- [x] 已运行 `luacheck main.lua _meta.lua weread spec`
- [ ] 如涉及插件加载/KOReader 兼容性，已运行或触发 `KOReader integration`
- [ ] 不适用，仅文档或注释变更

## 模块结构

项目自有 Lua 模块必须放在 `weread/` 命名空间下：

- 非 UI 模块：`weread/lib/`，使用 `require("weread.lib.<module>")`
- UI 模块：`weread/ui/`，使用 `require("weread.ui.<module>")`
- 禁止新增根级 `lib/`、`ui/` 项目模块或裸 `lib.*`、`ui.*` 模块键
- `require("ui/widget/menu")` 等 KOReader 自带模块不受此限制

## 截图

如果涉及 UI 或交互变更，请在这里添加截图或录屏。

## Checklist

- [x] 我已经说明这个 PR 解决的问题或新增的特性。
- [x] 如果是 bugfix，我已经提供复现步骤或关联 issue。
- [ ] 如果是新增 UI/交互特性，我已经提供截图或录屏。
- [x] 我没有提交 KOReader `settings/weread.lua`、API key、cookie、token、`x-wrpa-*` 或私人书籍内容。
- [x] 新增或移动的项目 Lua 模块遵循 `weread/lib/`、`weread/ui/` 命名空间规范。
- [x] 新增或修复的逻辑包含对应回归测试；若无法自动化，已在测试说明中解释原因。
- [ ] 如果修改了用户可见文本，我已经更新 `weread/lib/i18n.lua`。
- [ ] 如果修改了菜单结构，我已经同步更新 README 菜单结构。
- [ ] 如果涉及非公开 WeRead Web API，我已经在 `scripts/` 中提交可独立运行、可复现的 Python 验证脚本，并填写了复现命令和脱敏结果。
