### PR TITLE
Add Client:get_review_comments for review single endpoint

### DIFF
--- a/scripts/verify_review_single.py
+++ b/scripts/verify_review_single.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Verify WeRead GET /web/review/single (single review detail + comments).
+
+Usage:
+    python3 scripts/verify_review_single.py --cookie "wr_skey=XXX; wr_vid=XXX; ..."
+    python3 scripts/verify_review_single.py --cookie "..." --review-id "REVIEW_ID"
+
+Or set WEREAD_COOKIE env var. Provide --review-id from a thought that has comments,
+for example from /book/readreviews pageReviews[].reviewId in browser DevTools.
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/148.0.0.0 Safari/537.36"
+)
+
+
+def build_url(review_id, comments_count=20):
+    params = {
+        "reviewId": review_id,
+        "commentsCount": comments_count,
+        "commentsDirection": 0,
+        "likesCount": 0,
+        "synckey": 0,
+    }
+    query = urllib.parse.urlencode(params)
+    return f"https://weread.qq.com/web/review/single?{query}"
+
+
+def http_get(url, cookie):
+    headers = {
+        "Accept": "application/json, text/plain, */*",
+        "Referer": "https://weread.qq.com/",
+        "Cookie": cookie,
+        "User-Agent": UA,
+    }
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req) as resp:
+        return resp.read().decode("utf-8", errors="replace"), resp.status
+
+
+def redact(value, keep=4):
+    text = str(value or "")
+    if len(text) <= keep * 2:
+        return "***"
+    return f"{text[:keep]}...{text[-keep:]}"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify WeRead /web/review/single")
+    parser.add_argument("--cookie", default=os.environ.get("WEREAD_COOKIE", ""))
+    parser.add_argument(
+        "--review-id",
+        default="",
+        help="reviewId from pageReviews[].reviewId (required for live test)",
+    )
+    parser.add_argument("--comments-count", type=int, default=20)
+    args = parser.parse_args()
+
+    if not args.cookie:
+        print("ERROR: provide --cookie or set WEREAD_COOKIE", file=sys.stderr)
+        sys.exit(1)
+
+    print("=" * 60)
+    print("Test 1: /web/review/single without reviewId")
+    print("Expected: HTTP 4xx or empty/invalid payload")
+    print("=" * 60)
+    bad_url = build_url("")
+    try:
+        body, status = http_get(bad_url, args.cookie)
+        print(f"  Status: {status}, body_bytes: {len(body)}")
+        try:
+            data = json.loads(body)
+            print(f"  errCode: {data.get('errCode', 'none')}")
+        except json.JSONDecodeError:
+            print("  body is not JSON")
+    except urllib.error.HTTPError as exc:
+        print(f"  HTTPError: {exc.code}")
+    print()
+
+    if not args.review_id:
+        print("Skipping Test 2: no --review-id provided")
+        print("Provide a reviewId from readreviews pageReviews to verify comments.")
+        return
+
+    print("=" * 60)
+    print("Test 2: /web/review/single with reviewId")
+    print(f"  reviewId: {redact(args.review_id)}")
+    print("=" * 60)
+    url = build_url(args.review_id, args.comments_count)
+    body, status = http_get(url, args.cookie)
+    data = json.loads(body)
+    review_id = data.get("reviewId", "")
+    comments = data.get("comments") or []
+    comments_count = data.get("commentsCount", len(comments))
+    print(f"  Status: {status}")
+    print(f"  reviewId present: {bool(review_id)}")
+    print(f"  commentsCount: {comments_count}")
+    print(f"  comments returned: {len(comments)}")
+    if comments:
+        sample = comments[0]
+        author = (sample.get("author") or {}).get("name") or sample.get("author", "")
+        content = str(sample.get("content", ""))[:40].replace("\n", " ")
+        print(f"  first comment author: {redact(author)}")
+        print(f"  first comment preview: {content!r}")
+    if review_id:
+        print("  PASS: endpoint returned review detail payload")
+    else:
+        print("  WARN: response missing reviewId; check cookie or reviewId")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/spec/client_spec.lua
+++ b/spec/client_spec.lua
@@ -65,6 +65,11 @@ package.preload["weread.lib.protocol"] = function()
     return {
         USER_AGENT = "WeRead client spec",
         SKILL_VERSION = "test-skill",
+        urlencode = function(value)
+            return tostring(value):gsub("([^%w%-_%.~])", function(ch)
+                return string.format("%%%02X", ch:byte())
+            end)
+        end,
     }
 end
 
@@ -283,5 +288,46 @@ expect(not ok and tostring(err):find("error_code=-202", 1, true),
 local failure_log = table.concat(logs, "\n")
 expect(failure_log:find("shelf sync failed", 1, true),
     "shelf failure diagnostics were not written")
+
+local review_client = Client:new(settings)
+local ok_review, data_review, err_review = review_client:get_review_comments("")
+expect(not ok_review and err_review == "empty review_id",
+    "review comments rejected an empty review_id")
+
+responses[#responses + 1] = {
+    body = '{"reviewId":"r1","comments":[{"content":"hi"}],"commentsCount":1}',
+    code = 200,
+    headers = { ["content-type"] = "application/json" },
+}
+review_client.json_decode = function(_self, text)
+    return { reviewId = "r1", comments = { { content = "hi" } }, commentsCount = 1, _raw = text }
+end
+local review_request_index = #requests + 1
+ok_review, data_review, err_review = review_client:get_review_comments("r1", 60)
+expect(ok_review and type(data_review) == "table"
+    and data_review.commentsCount == 1 and err_review == nil,
+    "review comments did not return parsed data")
+local review_request = requests[review_request_index]
+local review_url = review_request and review_request.url or ""
+expect(review_url:find("/web/review/single?", 1, true)
+    and review_url:find("reviewId=r1", 1, true)
+    and review_url:find("commentsCount=60", 1, true)
+    and review_url:find("commentsDirection=0", 1, true)
+    and review_url:find("likesCount=0", 1, true)
+    and review_url:find("synckey=0", 1, true),
+    "review comments built the wrong URL: " .. tostring(review_url))
+
+responses[#responses + 1] = { body = "not-json", code = 200 }
+review_client.json_decode = function()
+    error("invalid JSON")
+end
+ok_review, data_review, err_review = review_client:get_review_comments("r2")
+expect(not ok_review and data_review == "not-json" and err_review == "invalid JSON",
+    "review comments did not surface JSON decode failures")
+
+responses[#responses + 1] = { body = "", code = 200 }
+ok_review, data_review, err_review = review_client:get_review_comments("r3")
+expect(not ok_review and err_review == "empty response",
+    "review comments did not reject an empty body")
 
 print(("client_spec: %d checks"):format(checks))

--- a/spec/client_spec.lua
+++ b/spec/client_spec.lua
@@ -290,7 +290,8 @@ expect(failure_log:find("shelf sync failed", 1, true),
     "shelf failure diagnostics were not written")
 
 local review_client = Client:new(settings)
-local ok_review, data_review, err_review = review_client:get_review_comments("")
+local ok_review, data_review, err_review
+ok_review, _, err_review = review_client:get_review_comments("")
 expect(not ok_review and err_review == "empty review_id",
     "review comments rejected an empty review_id")
 
@@ -326,7 +327,7 @@ expect(not ok_review and data_review == "not-json" and err_review == "invalid JS
     "review comments did not surface JSON decode failures")
 
 responses[#responses + 1] = { body = "", code = 200 }
-ok_review, data_review, err_review = review_client:get_review_comments("r3")
+ok_review, _, err_review = review_client:get_review_comments("r3")
 expect(not ok_review and err_review == "empty response",
     "review comments did not reject an empty body")
 

--- a/weread/lib/client.lua
+++ b/weread/lib/client.lua
@@ -752,4 +752,46 @@ function Client:get_chapter_reviews(book_id, chapter_uid, ranges)
     return true, { reviews = all_reviews }
 end
 
+function Client:get_review_comments(review_id, count, opts)
+    opts = opts or {}
+    if type(review_id) ~= "string" or review_id == "" then
+        return false, nil, "empty review_id"
+    end
+
+    local comments_count = count or 20
+    local url = "https://weread.qq.com/web/review/single"
+        .. "?reviewId=" .. WeRead.urlencode(review_id)
+        .. "&commentsCount=" .. tostring(comments_count)
+        .. "&commentsDirection=" .. tostring(opts.comments_direction or 0)
+        .. "&likesCount=" .. tostring(opts.likes_count or 0)
+        .. "&synckey=" .. tostring(opts.synckey or 0)
+
+    local ok, text, code, headers = pcall(function()
+        return self:get_text(url, {
+            accept = "application/json, text/plain, */*",
+            referer = opts.referer or "https://weread.qq.com/",
+            timeout = opts.timeout,
+        })
+    end)
+    if not ok then
+        return false, nil, tostring(text)
+    end
+    if not text or text == "" then
+        return false, nil, "empty response"
+    end
+
+    local decode_ok, parsed = pcall(function()
+        return self:decode_http_json(text, {
+            method = "GET",
+            url = url,
+            code = code,
+            headers = headers,
+        })
+    end)
+    if not decode_ok or type(parsed) ~= "table" then
+        return false, text, "invalid JSON"
+    end
+    return true, parsed, nil
+end
 return Client
+


### PR DESCRIPTION
Add the Web API client wrapper, regression tests, and a Python verification script for /web/review/single.

## 变更说明

 新增 Client:get_review_comments，封装 WeRead Web API GET /web/review/single，用于按 reviewId 拉取单条想法/评论详情。

 本 PR 仅包含 HTTP 客户端接口层 及对应测试

## 类型

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## 测试

- [x] 已在 KOReader 中手动测试
- [x] 已运行 `bash scripts/run_lua_specs.sh`
- [x] 已运行 `bash scripts/check_lua_namespace.sh`
- [x] 已运行 `luacheck main.lua _meta.lua weread spec`
- [ ] 如涉及插件加载/KOReader 兼容性，已运行或触发 `KOReader integration`
- [ ] 不适用，仅文档或注释变更

测试说明:

```text

```

## 非公开 WeRead API

如果本 PR 新增或修改任何非公开 WeRead Web API，必须同时在 `scripts/` 中提交一个可独立运行、可复现该接口行为的 Python 验证脚本。仅描述验证方式不能替代脚本。脚本不得打印或保存真实 API Key、Cookie、Token、完整 cURL 或账号标识。

- [ ] 不涉及非公开 WeRead API
- [x] 已新增或更新可复现的 Python 验证脚本

脚本路径:

```text
scripts/verify_review_single.py
```

复现命令与脱敏结果:

```text
python3 scripts/verify_review_single.py --cookie "..." --review-id "REVIEW_ID"
============================================================
Test 1: /web/review/single without reviewId
Expected: HTTP 4xx or empty/invalid payload
============================================================
  Status: 200, body_bytes: 64
  errCode: -2003

============================================================
Test 2: /web/review/single with reviewId
  reviewId: 6717...htXH
============================================================
  Status: 200
  reviewId present: True
  commentsCount: 3
  comments returned: 3
  first comment author: ***
  first comment preview: 'xxxx'
  PASS: endpoint returned review detail payload
```

## 模块结构

项目自有 Lua 模块必须放在 `weread/` 命名空间下：

- 非 UI 模块：`weread/lib/`，使用 `require("weread.lib.<module>")`
- UI 模块：`weread/ui/`，使用 `require("weread.ui.<module>")`
- 禁止新增根级 `lib/`、`ui/` 项目模块或裸 `lib.*`、`ui.*` 模块键
- `require("ui/widget/menu")` 等 KOReader 自带模块不受此限制

## 截图

如果涉及 UI 或交互变更，请在这里添加截图或录屏。

## Checklist

- [x] 我已经说明这个 PR 解决的问题或新增的特性。
- [ ] 如果是 bugfix，我已经提供复现步骤或关联 issue。
- [ ] 如果是新增 UI/交互特性，我已经提供截图或录屏。
- [x] 我没有提交 KOReader `settings/weread.lua`、API key、cookie、token、`x-wrpa-*` 或私人书籍内容。
- [x] 新增或移动的项目 Lua 模块遵循 `weread/lib/`、`weread/ui/` 命名空间规范。
- [x] 新增或修复的逻辑包含对应回归测试；若无法自动化，已在测试说明中解释原因。
- [ ] 如果修改了用户可见文本，我已经更新 `weread/lib/i18n.lua`。
- [ ] 如果修改了菜单结构，我已经同步更新 README 菜单结构。
- [x] 如果涉及非公开 WeRead Web API，我已经在 `scripts/` 中提交可独立运行、可复现的 Python 验证脚本，并填写了复现命令和脱敏结果。
