### PR TITLE
fix(ui): prevent empty-state font crashes

### DIFF
--- a/spec/empty_state_face_spec.lua
+++ b/spec/empty_state_face_spec.lua
@@ -1,0 +1,146 @@
+-- Regression coverage for full-screen views whose empty states use TextWidget.
+
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local checks = 0
+local function expect(condition, message)
+    checks = checks + 1
+    if not condition then error(message or ("check " .. checks .. " failed")) end
+end
+
+local Widget = {}
+Widget.__index = Widget
+
+function Widget:extend(defaults)
+    defaults = defaults or {}
+    defaults.__index = defaults
+    return setmetatable(defaults, { __index = self })
+end
+
+function Widget:new(values)
+    values = values or {}
+    setmetatable(values, { __index = self })
+    if values.init then values:init() end
+    return values
+end
+
+function Widget:getSize()
+    local dimen = self.dimen or {}
+    return { w = self.width or dimen.w or 100, h = self.height or dimen.h or 20 }
+end
+
+function Widget:getHeight()
+    return self:getSize().h
+end
+
+local function widget_module()
+    return Widget:extend{}
+end
+
+local shown = {}
+package.preload["ffi/blitbuffer"] = function()
+    return { COLOR_WHITE = 0, COLOR_BLACK = 1, COLOR_GRAY = 2 }
+end
+package.preload["ffi/util"] = function()
+    return {
+        template = function(text, ...)
+            local values = { ... }
+            return (text:gsub("%%(%d+)", function(index)
+                return tostring(values[tonumber(index)] or "")
+            end))
+        end,
+    }
+end
+package.preload["device"] = function()
+    return {
+        input = { group = { Back = "back" } },
+        hasKeys = function() return false end,
+        screen = {
+            getWidth = function() return 600 end,
+            getHeight = function() return 800 end,
+            scaleBySize = function(_self, value) return value end,
+        },
+    }
+end
+package.preload["ui/font"] = function()
+    return { getFace = function(_self, name, size) return { name = name, size = size } end }
+end
+package.preload["ui/geometry"] = function()
+    return {
+        new = function(_self, values)
+            values.copy = function(source)
+                local copy = {}
+                for key, value in pairs(source) do copy[key] = value end
+                return copy
+            end
+            return values
+        end,
+    }
+end
+package.preload["ui/size"] = function()
+    return {
+        border = { thin = 1 },
+        padding = { small = 2, default = 4, large = 8 },
+    }
+end
+package.preload["ui/uimanager"] = function()
+    return {
+        show = function(widget) shown[#shown + 1] = widget end,
+        close = function() end,
+        setDirty = function() end,
+    }
+end
+package.preload["ui/widget/textwidget"] = function()
+    local TextWidget = widget_module()
+    function TextWidget:new(values)
+        expect(values.face ~= nil, "TextWidget empty state must provide a font face")
+        return Widget.new(self, values)
+    end
+    return TextWidget
+end
+
+for _, name in ipairs({
+    "ui/gesturerange",
+    "ui/widget/button",
+    "ui/widget/container/framecontainer",
+    "ui/widget/container/inputcontainer",
+    "ui/widget/container/scrollablecontainer",
+    "ui/widget/horizontalgroup",
+    "ui/widget/horizontalspan",
+    "ui/widget/linewidget",
+    "ui/widget/titlebar",
+    "ui/widget/verticalgroup",
+    "ui/widget/verticalspan",
+}) do
+    package.preload[name] = widget_module
+end
+
+package.preload["weread.lib.i18n"] = function()
+    return { tr = function(text) return text end }
+end
+package.preload["weread.lib.book_reviews"] = function()
+    return {
+        format_date = function() return "" end,
+        format_rating = tostring,
+        preview = function(text) return text end,
+    }
+end
+
+local LibraryView = require("weread.ui.library_view")
+local ok, error_message = pcall(function()
+    LibraryView.show({ mode = "books", books = {}, accounts = {} }, {})
+end)
+expect(ok, "empty bookshelf failed to build: " .. tostring(error_message))
+
+local BookReviewsView = require("weread.ui.book_reviews_view")
+ok, error_message = pcall(function()
+    BookReviewsView.show({
+        book_title = "Book",
+        mode = "recommended",
+        result = { items = {} },
+    }, {})
+end)
+expect(ok, "empty review list failed to build: " .. tostring(error_message))
+expect(#shown == 2, "both empty-state views should be shown")
+
+print(("empty_state_face_spec: %d checks"):format(checks))

--- a/weread/ui/book_reviews_view.lua
+++ b/weread/ui/book_reviews_view.lua
@@ -4,6 +4,7 @@
 local Blitbuffer = require("ffi/blitbuffer")
 local Button = require("ui/widget/button")
 local Device = require("device")
+local Font = require("ui/font")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local Geom = require("ui/geometry")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
@@ -98,6 +99,7 @@ function BookReviewsView:buildContent()
         table.insert(content, VerticalSpan:new{ width = Size.padding.large })
         table.insert(content, TextWidget:new{
             text = _("No reviews."),
+            face = Font:getFace("cfont", 18),
             max_width = self.content_width,
         })
         return content

--- a/weread/ui/library_view.lua
+++ b/weread/ui/library_view.lua
@@ -216,6 +216,7 @@ function LibraryView:content()
         table.insert(content, VerticalSpan:new{ width = Size.padding.large })
         table.insert(content, TextWidget:new{
             text = self.keyword and self.keyword ~= "" and _("No shelf matches.") or _("No items."),
+            face = Font:getFace("cfont", 20),
             max_width = self.content_width,
         })
         return content


### PR DESCRIPTION
## 变更说明

在 Kindle 的 KOReader 中打开微信读书书架时，如果搜索或筛选后列表为空，KOReader 会在绘制空状态文本时崩溃：

```text
frontend/ui/font.lua:386: attempt to index local 'face' (a nil value)
```

根因是书架空状态直接创建了 `TextWidget`，但没有提供 KOReader 必需的 `face`。书评列表的空状态也存在相同隐患。

本 PR：

- 为书架空状态补充显式的 `cfont` 字体；
- 为书评空状态补充显式的 `cfont` 字体；
- 新增回归测试，构建两个空状态视图并确保所有 `TextWidget` 都提供字体。

## 类型

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Bugfix 要求

修复前复现步骤：

1. 在 Kindle PaperWhite 3、KOReader v2026.03 中安装插件 v1.0.0。
2. 打开微信读书书架。
3. 使用搜索或筛选，使当前书架列表变为 0 条。
4. KOReader 在测量或绘制空状态文本时退出，日志出现 `font.lua:386` 的空字体对象错误。
5. 重启后，由于缓存书架和筛选条件仍然存在，可能再次触发崩溃。

## Feature 要求

不适用，本 PR 不新增特性。

## 测试

- [x] 已在 KOReader 中手动测试
- [x] 已运行 `bash scripts/run_lua_specs.sh`
- [x] 已运行 `bash scripts/check_lua_namespace.sh`
- [ ] 已运行 `luacheck main.lua _meta.lua weread spec`
- [ ] 如涉及插件加载/KOReader 兼容性，已运行或触发 `KOReader integration`
- [ ] 不适用，仅文档或注释变更

测试说明:

```text
- 已将修复后的插件发布到触发问题的 Kindle PaperWhite 3，重新进入空书架状态后不再崩溃。
- 33 个独立 Lua 规格全部通过。本机使用 Lua 5.4 和临时 bit 兼容层运行测试脚本。
- scripts/check_lua_namespace.sh 通过。
- 所有 Lua 文件通过 luac -p。
- scripts/*.py 通过 py_compile。
- 发布包生成及压缩包完整性校验通过。
- 敏感凭据扫描无匹配。
- 本机没有可用的原生 LuaJIT 和 luacheck；这两项由仓库 CI 在标准环境中继续校验。
```

## 非公开 WeRead API

- [x] 不涉及非公开 WeRead API
- [ ] 已新增或更新可复现的 Python 验证脚本

脚本路径:

```text
不适用。
```

复现命令与脱敏结果:

```text
不适用。
```

## 模块结构

符合规范。本 PR 只修改现有的 `weread/ui/library_view.lua`、`weread/ui/book_reviews_view.lua`，并在 `spec/` 下新增回归测试；没有新增或移动项目 Lua 模块。

## 截图

不适用。本 PR 不新增或改变 UI，仅修复空列表状态下的崩溃。

## Checklist

- [x] 我已经说明这个 PR 解决的问题或新增的特性。
- [x] 如果是 bugfix，我已经提供复现步骤或关联 issue。
- [ ] 如果是新增 UI/交互特性，我已经提供截图或录屏。（不适用：未新增 UI 或交互）
- [x] 我没有提交 KOReader `settings/weread.lua`、API key、cookie、token、`x-wrpa-*` 或私人书籍内容。
- [x] 新增或移动的项目 Lua 模块遵循 `weread/lib/`、`weread/ui/` 命名空间规范。（不适用：未新增或移动模块）
- [x] 新增或修复的逻辑包含对应回归测试；若无法自动化，已在测试说明中解释原因。
- [x] 如果修改了用户可见文本，我已经更新 `weread/lib/i18n.lua`。（不适用：未修改用户可见文本）
- [x] 如果修改了菜单结构，我已经同步更新 README 菜单结构。（不适用：未修改菜单结构）
- [x] 如果涉及非公开 WeRead Web API，我已经在 `scripts/` 中提交可独立运行、可复现的 Python 验证脚本，并填写了复现命令和脱敏结果。（不适用：不涉及非公开 API）
