### PR TITLE
fix: guard uninitialized highlight tap state

### DIFF
--- a/spec/reader_lifecycle_highlight_spec.lua
+++ b/spec/reader_lifecycle_highlight_spec.lua
@@ -1,0 +1,71 @@
+-- Regression coverage for KOReader's transient nil visible_boxes cache.
+
+package.path = "./?.lua;" .. package.path
+
+package.preload["weread.lib.content"] = function() return {} end
+package.preload["weread.lib.logger"] = function()
+    return { scoped = function() return {} end }
+end
+package.preload["weread.lib.protocol"] = function()
+    return { is_mp_book = function() return false end }
+end
+package.preload["ui/uimanager"] = function() return {} end
+package.preload["weread.lib.plugin_util"] = function()
+    return {
+        tr = function(text) return text end,
+        T = function(text) return text end,
+        display_error = tostring,
+        file_exists = function() return false end,
+        log_error = tostring,
+    }
+end
+
+local Lifecycle = require("weread.lib.reader_lifecycle")
+
+local checks, failures = 0, 0
+local function expect(value, label)
+    checks = checks + 1
+    if not value then
+        failures = failures + 1
+        print("FAIL " .. label)
+    end
+end
+
+local calls = 0
+local original = function(self, arg, ges)
+    calls = calls + 1
+    return self.view.highlight.visible_boxes, arg, ges
+end
+local reader_highlight = {
+    view = { highlight = {} },
+    onTap = original,
+}
+local host = { ui = { highlight = reader_highlight } }
+for key, value in pairs(Lifecycle) do host[key] = value end
+
+expect(host:_installReaderHighlightTapGuard(), "guard installs on ReaderHighlight")
+expect(reader_highlight.onTap ~= original, "native tap handler is wrapped")
+
+local boxes, arg, ges = reader_highlight:onTap("arg", { pos = { x = 1, y = 2 } })
+expect(type(boxes) == "table" and #boxes == 0,
+    "tap initializes a missing visible box cache")
+expect(calls == 1 and arg == "arg" and ges.pos.x == 1,
+    "guard delegates to the native handler unchanged")
+
+local existing = { { index = 1 } }
+reader_highlight.view.highlight.visible_boxes = existing
+boxes = reader_highlight:onTap(nil, { pos = { x = 3, y = 4 } })
+expect(boxes == existing, "an initialized visible box cache is preserved")
+
+expect(host:_installReaderHighlightTapGuard(), "reinstall is idempotent")
+host:_removeReaderHighlightTapGuard()
+expect(reader_highlight.onTap == original, "document close restores native handler")
+
+host.ui.highlight = nil
+expect(not host:_installReaderHighlightTapGuard(),
+    "missing ReaderHighlight module degrades safely")
+
+print(string.format(
+    "reader_lifecycle_highlight_spec: %d checks, %d failure(s)",
+    checks, failures))
+os.exit(failures == 0 and 0 or 1)

--- a/weread/lib/reader_lifecycle.lua
+++ b/weread/lib/reader_lifecycle.lua
@@ -12,6 +12,45 @@ local log_error = PluginUtil.log_error
 
 local M = {}
 
+-- KOReader v2026.03 assumes ReaderHighlight's visible box cache has already
+-- been populated when a tap arrives. During a fast document switch there is a
+-- short window after ReaderReady where the cache is still nil, and the native
+-- handler crashes while taking its length. Keep the compatibility guard local
+-- to the reader instance and leave KOReader's normal handler unchanged once
+-- the cache has been initialized.
+function M:_installReaderHighlightTapGuard()
+    local highlight = self.ui and self.ui.highlight
+    if not highlight or type(highlight.onTap) ~= "function" then
+        return false
+    end
+    if self._reader_highlight_guard_target == highlight then
+        return true
+    end
+    self:_removeReaderHighlightTapGuard()
+
+    local original = highlight.onTap
+    self._reader_highlight_guard_target = highlight
+    self._reader_highlight_original_on_tap = original
+    highlight.onTap = function(highlight_self, arg, ges)
+        local view_highlight = highlight_self.view and highlight_self.view.highlight
+        if ges and view_highlight and type(view_highlight.visible_boxes) ~= "table" then
+            view_highlight.visible_boxes = {}
+        end
+        return original(highlight_self, arg, ges)
+    end
+    return true
+end
+
+function M:_removeReaderHighlightTapGuard()
+    local highlight = self._reader_highlight_guard_target
+    local original = self._reader_highlight_original_on_tap
+    if highlight and original and highlight.onTap ~= original then
+        highlight.onTap = original
+    end
+    self._reader_highlight_guard_target = nil
+    self._reader_highlight_original_on_tap = nil
+end
+
 function M:onShowWeRead()
     self:showAccountStatus()
 end
@@ -67,6 +106,7 @@ end
 function M:onReaderReady()
     self._reader_session_gen = (self._reader_session_gen or 0) + 1
     self:_teardownThoughtInterception()
+    self:_installReaderHighlightTapGuard()
 
     local weread_book_id = self:detectWeReadBook()
     -- Cache it so the per-tap handler (_onThoughtTap) does not have to re-scan
@@ -126,6 +166,7 @@ function M:onCloseDocument()
     self.downloader:cancelPrefetch("document_closed")
     self._current_weread_book_id = nil
     self:_teardownThoughtInterception()
+    self:_removeReaderHighlightTapGuard()
 
     if self._orig_onEndOfBook and self.ui.status then
         self.ui.status.onEndOfBook = self._orig_onEndOfBook


### PR DESCRIPTION
## 变更说明

请说明这个 PR 解决了什么问题，或者新增了什么特性。

## 类型

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Bugfix 要求

如果这是 bugfix，请至少提供以下其中一项：

Ref #112 

## Feature 要求

如果这是新增特性，请说明：

- 新增了什么能力
- 典型使用场景
- 如果涉及 UI、菜单、弹窗、排版或交互，请提供截图或录屏

## 测试

请说明你如何验证这个 PR。

- [ ] 已在 KOReader 中手动测试
- [ ] 已运行 `bash scripts/run_lua_specs.sh`
- [ ] 已运行 `bash scripts/check_lua_namespace.sh`
- [ ] 已运行 `luacheck main.lua _meta.lua weread spec`
- [ ] 如涉及插件加载/KOReader 兼容性，已运行或触发 `KOReader integration`
- [ ] 不适用，仅文档或注释变更

测试说明:

```text

```

## 非公开 WeRead API

如果本 PR 新增或修改任何非公开 WeRead Web API，必须同时在 `scripts/` 中提交一个可独立运行、可复现该接口行为的 Python 验证脚本。仅描述验证方式不能替代脚本。脚本不得打印或保存真实 API Key、Cookie、Token、完整 cURL 或账号标识。

- [ ] 不涉及非公开 WeRead API
- [ ] 已新增或更新可复现的 Python 验证脚本

脚本路径:

```text
scripts/
```

复现命令与脱敏结果:

```text

```

## 模块结构

项目自有 Lua 模块必须放在 `weread/` 命名空间下：

- 非 UI 模块：`weread/lib/`，使用 `require("weread.lib.<module>")`
- UI 模块：`weread/ui/`，使用 `require("weread.ui.<module>")`
- 禁止新增根级 `lib/`、`ui/` 项目模块或裸 `lib.*`、`ui.*` 模块键
- `require("ui/widget/menu")` 等 KOReader 自带模块不受此限制

## 截图

如果涉及 UI 或交互变更，请在这里添加截图或录屏。

## Checklist

- [x] 我已经说明这个 PR 解决的问题或新增的特性。
- [x] 如果是 bugfix，我已经提供复现步骤或关联 issue。
- [x] 如果是新增 UI/交互特性，我已经提供截图或录屏。
- [x] 我没有提交 KOReader `settings/weread.lua`、API key、cookie、token、`x-wrpa-*` 或私人书籍内容。
- [x] 新增或移动的项目 Lua 模块遵循 `weread/lib/`、`weread/ui/` 命名空间规范。
- [x] 新增或修复的逻辑包含对应回归测试；若无法自动化，已在测试说明中解释原因。
- [x] 如果修改了用户可见文本，我已经更新 `weread/lib/i18n.lua`。
- [x] 如果修改了菜单结构，我已经同步更新 README 菜单结构。
- [x] 如果涉及非公开 WeRead Web API，我已经在 `scripts/` 中提交可独立运行、可复现的 Python 验证脚本，并填写了复现命令和脱敏结果。
