### PR TITLE
fix(download): avoid incomplete full-book EPUBs

### DIFF
--- a/spec/download_disk_assets_spec.lua
+++ b/spec/download_disk_assets_spec.lua
@@ -24,6 +24,28 @@ package.preload["weread.lib.thoughts"] = function() return {} end
 local archive_calls = {}
 local archive_should_fail = false
 package.preload["ffi/archiver"] = function()
+    local Reader = {}
+    function Reader:new() return setmetatable({}, { __index = self }) end
+    function Reader:open(path)
+        self.path = path
+        self.index = 0
+        return true
+    end
+    function Reader:iterate()
+        local entries = {
+            { path = "converted/page-1.jpeg", mode = "file", size = 7 },
+            { path = "converted/metadata.json", mode = "file", size = 2 },
+        }
+        return function()
+            self.index = self.index + 1
+            return entries[self.index]
+        end
+    end
+    function Reader:extractToMemory(path)
+        if path:match("[.]jpeg$") then return "\255\216\255jpeg" end
+        return "{}"
+    end
+    function Reader:close() end
     local Writer = {}
     function Writer:new() return setmetatable({}, { __index = self }) end
     function Writer:open(path)
@@ -56,7 +78,7 @@ package.preload["ffi/archiver"] = function()
         return false
     end
     function Writer:close() end
-    return { Writer = Writer }
+    return { Reader = Reader, Writer = Writer }
 end
 package.preload["ffi/util"] = function()
     return {
@@ -146,6 +168,26 @@ expect(first:read(3) == "\255\216\255", "extracted image bytes were corrupted")
 first:close()
 expect(io.open(workspace.incoming_dir .. "/chapter-7.tar", "rb") == nil,
     "source TAR was not removed after extraction")
+
+function fake_client:download_to_file(_url, path)
+    local file = assert(io.open(path, "wb"))
+    file:write("PK\003\004fake converted-book ZIP")
+    file:close()
+    return path
+end
+local zip_assets, zip_src_map = Content.download_chapter_assets_to_files(
+    fake_client, { book_id = "converted-book" },
+    { chapterUid = 1, tar = "https://example.test/resources" },
+    {}, workspace)
+expect(#zip_assets == 1, "ZIP image resources were not extracted")
+local zip_image = assert(io.open(zip_assets[1].path, "rb"))
+expect(zip_image:read(3) == "\255\216\255",
+    "ZIP image was not staged on disk")
+zip_image:close()
+expect(zip_src_map["page-1.jpeg"] == "../" .. zip_assets[1].href,
+    "ZIP image map was wrong")
+expect(io.open(workspace.incoming_dir .. "/chapter-1.tar", "rb") == nil,
+    "source ZIP was not removed after extraction")
 
 local settings = {
     cache_dir = root,

--- a/spec/downloader_completion_spec.lua
+++ b/spec/downloader_completion_spec.lua
@@ -43,10 +43,15 @@ package.preload["ffi/util"] = function()
         end,
     }
 end
+local full_book_save_count = 0
 package.preload["weread.lib.content"] = function()
     return {
         save_chapter_epub = function(_settings, _book, chapter)
             return "/cache/book/chapter-" .. tostring(chapter.chapterUid) .. ".epub"
+        end,
+        save_book_epub = function()
+            full_book_save_count = full_book_save_count + 1
+            return "/cache/book/replacement-full.epub"
         end,
     }
 end
@@ -87,6 +92,7 @@ local live_books = {
     },
 }
 local opened
+local info_messages = {}
 local completion_count = 0
 local completion_ok
 local completion_path
@@ -107,7 +113,8 @@ local downloader = Downloader:new{
     client = {},
     refresh_shelf = function() end,
     open_file = function(path) opened = path end,
-    show_info = function() end,
+    show_info = function(text) info_messages[#info_messages + 1] = text end,
+    show_transient = function() end,
 }
 local chapter = { chapterUid = 22, title = "Target" }
 local download = {
@@ -178,6 +185,49 @@ eq(stored_books.book.cached_chapters["33"],
     "/cache/book/chapter-33.epub", "second selected chapter persisted separately")
 eq(stored_books.book.cached_full_book, "/cache/book/full.epub",
     "partial download preserved the full-book cache")
+
+local incomplete_full_completion_count = 0
+local incomplete_full_completion_ok
+local incomplete_full_completion_value
+local incomplete_full = {
+    book = {
+        book_id = "book",
+        title = "Book",
+        cached_file = "/cache/book/full.epub",
+        cached_full_book = "/cache/book/full.epub",
+    },
+    chapters = { chapter, chapter_33 },
+    selected = { chapter },
+    bodies = { ["22"] = "<p>22</p>" },
+    assets = {},
+    state = { css = "" },
+    suffix = "full",
+    index = 3,
+    total = 2,
+    failed = { "33" },
+    annotation_failed_batches = 0,
+    started_at = 999,
+    on_complete = function(ok, value)
+        incomplete_full_completion_count = incomplete_full_completion_count + 1
+        incomplete_full_completion_ok = ok
+        incomplete_full_completion_value = value
+    end,
+}
+downloader:_step(incomplete_full)
+eq(full_book_save_count, 0,
+    "incomplete full-book download did not build a partial EPUB")
+eq(stored_books.book.cached_full_book, "/cache/book/full.epub",
+    "incomplete full-book download preserved the existing full cache")
+eq(stored_books.book.cached_file, "/cache/book/full.epub",
+    "incomplete full-book download preserved the compatibility cache alias")
+eq(incomplete_full_completion_count, 1,
+    "incomplete full-book completion callback count")
+eq(incomplete_full_completion_ok, false,
+    "incomplete full-book completion reported failure")
+eq(incomplete_full_completion_value, "incomplete_full_book",
+    "incomplete full-book completion reason")
+eq(#info_messages, 1,
+    "incomplete full-book failure was shown to the user")
 
 print(string.format(
     "downloader_completion_spec: %d checks, %d failure(s)", checks, failures))

--- a/spec/downloader_lifecycle_spec.lua
+++ b/spec/downloader_lifecycle_spec.lua
@@ -53,6 +53,9 @@ end
 package.preload["weread.lib.content"] = function()
     return {
         ensure_reader_state = function() end,
+        fetch_single_chapter_source = function()
+            error("injected transient timeout")
+        end,
     }
 end
 package.preload["weread.ui.download_dialog"] = function()
@@ -155,5 +158,25 @@ expect(downloader._standby_ref == 0 and allowed == 2,
     "guarded failure leaked the standby guard")
 expect(#messages >= 2, "lifecycle failures were not surfaced to the user")
 expect(prevented == 0, "test unexpectedly acquired a standby guard")
+
+local retry_download = {
+    book = { book_id = "book" },
+    chapters = { { chapterUid = 30, title = "Chapter 30" } },
+    index = 1,
+    total = 1,
+    failed = {},
+}
+local scheduled_before_retry = #scheduled
+downloader:_step(retry_download)
+expect(retry_download.index == 1 and #retry_download.failed == 0,
+    "first transient chapter failure was not retained for retry")
+expect(#scheduled == scheduled_before_retry + 1,
+    "first chapter retry was not scheduled")
+scheduled[#scheduled]()
+expect(retry_download.index == 1 and #retry_download.failed == 0,
+    "second transient chapter failure was not retained for retry")
+scheduled[#scheduled]()
+expect(retry_download.index == 2 and retry_download.failed[1] == "30",
+    "chapter was not skipped after exhausting two retries")
 
 print(("downloader_lifecycle_spec: %d checks"):format(checks))

--- a/weread/lib/content.lua
+++ b/weread/lib/content.lua
@@ -1018,6 +1018,57 @@ end
 local MAX_TAR_ENTRY_BYTES = 512 * 1024 * 1024
 local FILE_COPY_CHUNK_BYTES = 64 * 1024
 
+-- WeRead's catalog field is named `tar`, but cloud-converted documents may
+-- point it at a ZIP archive instead. KOReader already ships libarchive, so use
+-- its format auto-detection for those resources while keeping the small TAR
+-- reader below for the common streaming path.
+local function extract_zip_images(archive_path, asset_dir, used_names)
+    local Archiver = require("ffi/archiver")
+    local archive = Archiver.Reader:new()
+    local assets = {}
+    local src_map = {}
+    local ok, err = xpcall(function()
+        if not archive:open(archive_path) then
+            error(archive.err or "could not open chapter resource archive")
+        end
+        for entry in archive:iterate() do
+            if entry.mode == "file" and entry.size > 0 then
+                if entry.size > MAX_TAR_ENTRY_BYTES then
+                    error("chapter resource archive entry is too large")
+                end
+                local data = archive:extractToMemory(entry.path)
+                if not data then
+                    error(archive.err or "could not extract chapter resource")
+                end
+                local ext, media_type = media_type_for(data)
+                if media_type:match("^image/") then
+                    local stem = basename(entry.path)
+                    local filename = unique_asset_name(used_names, stem, ext)
+                    local href = "images/" .. filename
+                    local asset = { href = href, media_type = media_type }
+                    if asset_dir then
+                        local output = assert(io.open(asset_dir .. "/" .. filename, "wb"))
+                        assert(output:write(data))
+                        output:close()
+                        asset.path = asset_dir .. "/" .. filename
+                        asset.size = #data
+                        asset.store = true
+                    else
+                        asset.data = data
+                    end
+                    table.insert(assets, asset)
+                    local epub_relative = "../" .. href
+                    src_map[stem] = epub_relative
+                    src_map[filename] = epub_relative
+                end
+            end
+        end
+    end, debug.traceback)
+    archive:close()
+    if not ok then error(err, 0) end
+    return assets, src_map
+end
+
 local function extract_tar_images(tar_path, asset_dir, used_names)
     local input, open_err = io.open(tar_path, "rb")
     if not input then error(open_err or "could not open chapter resource archive") end
@@ -1105,8 +1156,13 @@ function Content.download_chapter_assets_to_files(client, book, chapter, used_na
         referer = referer,
         max_bytes = MAX_TAR_ENTRY_BYTES,
     })
+    local input = assert(io.open(tar_path, "rb"))
+    local signature = input:read(4) or ""
+    input:close()
+    local extractor = signature:sub(1, 2) == "PK"
+        and extract_zip_images or extract_tar_images
     local ok, assets, src_map = pcall(
-        extract_tar_images, tar_path, workspace.asset_dir, used_names)
+        extractor, tar_path, workspace.asset_dir, used_names)
     pcall(os.remove, tar_path)
     if not ok then error(assets, 0) end
     return assets, src_map

--- a/weread/lib/downloader.lua
+++ b/weread/lib/downloader.lua
@@ -526,6 +526,29 @@ function Downloader:_failChapter(dl, err)
     self:_scheduleGuarded(dl, function() self:_step(dl) end)
 end
 
+function Downloader:_retryChapterSource(dl, err)
+    local chapter = dl.chapters[dl.index]
+    local uid = tostring(chapter and chapter.chapterUid or dl.index)
+    dl.chapter_source_retries = dl.chapter_source_retries or {}
+    local attempt = (dl.chapter_source_retries[uid] or 0) + 1
+    dl.chapter_source_retries[uid] = attempt
+    if attempt > 2 then
+        dl.chapter_source_retries[uid] = nil
+        self:_failChapter(dl, err)
+        return false
+    end
+    logger.warn("chapter source download failed; retrying:",
+        "index=", tostring(dl.index) .. "/" .. tostring(dl.total),
+        "chapter_uid=", uid, "attempt=", tostring(attempt),
+        "error=", log_error(err))
+    self:_setStage(dl,
+        T(_("Retrying chapter %1/%2 · attempt %3"),
+            tostring(dl.index), tostring(dl.total), tostring(attempt)),
+        dl.index - 1)
+    self:_scheduleGuarded(dl, function() self:_step(dl) end, 0.8 * attempt)
+    return true
+end
+
 local function add_footnote_stats(total, current)
     for _i, key in ipairs({
         "candidates", "converted", "image_notes", "backlinks",
@@ -1053,8 +1076,11 @@ function Downloader:_step(dl)
     end)
     self:_perf(dl, "chapter_source", started, "ok=", tostring(ok))
     if not ok then
-        self:_failChapter(dl, xhtml)
+        self:_retryChapterSource(dl, xhtml)
         return
+    end
+    if dl.chapter_source_retries then
+        dl.chapter_source_retries[tostring(chapter.chapterUid or dl.index)] = nil
     end
     local uid = tostring(chapter.chapterUid or dl.index)
     local scan_ok, scan = pcall(Footnotes.scan_chapter, xhtml, chapter)

--- a/weread/lib/downloader.lua
+++ b/weread/lib/downloader.lua
@@ -826,6 +826,32 @@ function Downloader:_step(dl)
             end
             return
         end
+        -- A full-book cache must be complete. Saving the chapters that happened
+        -- to succeed under the stable `full.epub` path makes KOReader present a
+        -- structurally valid but truncated book and replaces any previous good
+        -- cache. Explicit single- or multi-chapter jobs remain best-effort.
+        if dl.suffix == "full" and #dl.failed > 0 then
+            if dl.progress_dialog then
+                dl.progress_dialog:close()
+                dl.progress_dialog = nil
+            end
+            self:_releaseStandby(dl)
+            self:_cleanupWorkspace(dl)
+            logger.warn(
+                "full-book download aborted after chapter failures:",
+                "success=", tostring(#dl.selected),
+                "failed=", tostring(#dl.failed),
+                "total=", tostring(dl.total)
+            )
+            self:_notifyCompletion(dl, false, "incomplete_full_book")
+            self:_finishJob(dl)
+            if not dl.prefetch then
+                self.show_info(T(_(
+                    "Full-book download stopped: %1 of %2 chapters failed.\n\nNo incomplete EPUB was saved. Please retry the download."
+                ), tostring(#dl.failed), tostring(dl.total)))
+            end
+            return
+        end
         if dl.footnote_scans and not dl.footnotes_done then
             self:_startFootnotes(dl)
             return

--- a/weread/lib/i18n.lua
+++ b/weread/lib/i18n.lua
@@ -256,6 +256,7 @@ local zh = {
     ["Downloading underlines · chapter %1/%2"] = "正在下载划线 · 章节 %1/%2",
     ["Downloading thoughts %1/%2 · chapter %3/%4"] = "正在下载想法 %1/%2 · 章节 %3/%4",
     ["Retrying thoughts %1/%2 · attempt %3"] = "正在重试想法 %1/%2 · 第 %3 次",
+    ["Retrying chapter %1/%2 · attempt %3"] = "正在重试章节 %1/%2 · 第 %3 次",
     ["Processing underlines and thoughts · chapter %1/%2"] = "正在处理划线和想法 · 章节 %1/%2",
     ["Downloading images · chapter %1/%2"] = "正在下载图片 · 章节 %1/%2",
     ["Processing chapter %1/%2"] = "正在处理章节 %1/%2",

--- a/weread/lib/i18n.lua
+++ b/weread/lib/i18n.lua
@@ -170,6 +170,7 @@ local zh = {
     ["Next chapter prefetch failed: %1"] = "下一章预下载失败：%1",
     ["Network is not connected"] = "网络未连接",
     ["No chapters were downloaded."] = "没有成功下载任何章节。",
+    ["Full-book download stopped: %1 of %2 chapters failed.\n\nNo incomplete EPUB was saved. Please retry the download."] = "整本下载已停止：共 %2 章，其中 %1 章失败。\n\n未保存残缺的 EPUB，请重试下载。",
     ["No readable chapter found"] = "没有可阅读的章节。",
     ["Read now"] = "立即阅读",
     ["Pull progress"] = "拉取进度",


### PR DESCRIPTION
## 变更说明

修复整本下载在部分章节失败时仍生成残缺 EPUB 的问题，并提高云端转换文档的下载可靠性：

- 任一章节失败时，不生成或覆盖整本 `full.epub`。
- 兼容目录 `tar` 字段实际返回 ZIP 资源包的情况；ZIP 使用 KOReader 自带 libarchive 解压，原有 TAR 流式路径保持不变。
- 章节正文请求失败后延迟重试两次，重试耗尽后才将章节标记为失败。
- 单章和用户明确选择的分章节下载仍保持 best-effort 行为。

## 类型

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Bugfix 要求

修复前的清晰复现步骤：

1. 选择一本包含较多章节的书，执行整本下载。
2. 令任一章节请求失败，例如阅读页请求发生瞬时超时。
3. 修复前，下载器跳过失败章节后仍生成 `full.epub`；该文件结构有效、可以由 KOReader 打开，但正文缺章，并可能覆盖先前完整缓存。
4. 对部分云端转换文档，目录的 `tar` 字段会返回 ZIP 文件。修复前插件固定按 TAR 解析，导致资源处理阶段失败。

## Feature 要求

不适用，本 PR 不新增特性或 UI。

## 测试

- [x] 已在 KOReader 中手动测试
- [x] 已运行 `bash scripts/run_lua_specs.sh`
- [x] 已运行 `bash scripts/check_lua_namespace.sh`
- [x] 已运行 `luacheck main.lua _meta.lua weread spec`
- [x] 如涉及插件加载/KOReader 兼容性，已运行或触发 `KOReader integration`
- [ ] 不适用，仅文档或注释变更

测试说明:

```text
- 37 个 Lua specs 全部通过。
- luacheck: 86 files, 0 warnings / 0 errors。
- 固定 KOReader commit 的 PluginLoader integration: 2 tests passed。
- python3 -m py_compile scripts/*.py 通过。
- release package smoke test 通过。
- 在 KOReader 中手动完成含 ZIP 图片资源的云端转换文档整本下载；一次瞬时章节超时经自动重试后成功，最终 EPUB 完整生成。
```

## 非公开 WeRead API

- [x] 不涉及非公开 WeRead API
- [ ] 已新增或更新可复现的 Python 验证脚本

脚本路径:

```text
不适用；未新增或修改接口、端点、参数或认证流程。
```

复现命令与脱敏结果:

```text
不适用。本 PR 仅处理既有目录资源返回的归档格式，并为既有章节下载流程增加重试。
```

## 模块结构

未新增或移动模块。修改保持在 `weread/lib/` 命名空间内。

## 截图

不适用；未新增 UI、菜单、弹窗或交互结构。仅新增已有下载进度标题中的重试状态文本。

## Checklist

- [x] 我已经说明这个 PR 解决的问题或新增的特性。
- [x] 如果是 bugfix，我已经提供复现步骤或关联 issue。
- [x] 如果是新增 UI/交互特性，我已经提供截图或录屏。（不适用，未新增 UI/交互特性）
- [x] 我没有提交 KOReader `settings/weread.lua`、API key、cookie、token、`x-wrpa-*` 或私人书籍内容。
- [x] 新增或移动的项目 Lua 模块遵循 `weread/lib/`、`weread/ui/` 命名空间规范。（未新增或移动模块）
- [x] 新增或修复的逻辑包含对应回归测试；若无法自动化，已在测试说明中解释原因。
- [x] 如果修改了用户可见文本，我已经更新 `weread/lib/i18n.lua`。
- [x] 如果修改了菜单结构，我已经同步更新 README 菜单结构。（不适用，未修改菜单）
- [x] 如果涉及非公开 WeRead Web API，我已经在 `scripts/` 中提交可独立运行、可复现的 Python 验证脚本，并填写了复现命令和脱敏结果。（不适用，未新增或修改 API）