### PR TITLE
fix(progress-sync): retry automatic pull when the link is not ready

### DIFF
--- a/spec/progress_sync_spec.lua
+++ b/spec/progress_sync_spec.lua
@@ -22,6 +22,9 @@ local function test(name, fn)
     fn()
 end
 
+-- Mirrors PULL_RETRY_DELAY_SECONDS in weread/lib/progress_sync.lua.
+local PULL_RETRY_DELAY_SECONDS = 15
+
 local chapters = {
     { chapterUid = 11, chapterIdx = 1, wordCount = 100 },
     { chapterUid = 22, chapterIdx = 2, wordCount = 300 },
@@ -68,8 +71,8 @@ local function fixture(remote, options)
     }
     local queue = {}
     local scheduler = {
-        scheduleIn = function(_self, _delay, callback)
-            queue[#queue + 1] = callback
+        scheduleIn = function(_self, delay, callback)
+            queue[#queue + 1] = { delay = delay, callback = callback }
         end,
     }
     local choices = {}
@@ -119,12 +122,18 @@ local function fixture(remote, options)
         end,
         is_online = options.is_online,
     }
+    local function step()
+        local entry = table.remove(queue, 1)
+        if not entry then return false end
+        entry.callback()
+        return true
+    end
     local function drain()
         local count = 0
         while #queue > 0 do
             count = count + 1
             assert(count < 20, "scheduler did not quiesce")
-            table.remove(queue, 1)()
+            step()
         end
     end
     return {
@@ -135,6 +144,8 @@ local function fixture(remote, options)
         uploads = uploads,
         jumps = jumps,
         notifications = notifications,
+        queue = queue,
+        step = step,
         drain = drain,
     }
 end
@@ -426,6 +437,87 @@ test("offline manual catalog refresh reports offline instead of raw reason", fun
     eq(refresh_count, 0, "offline path does not refresh")
     eq(#f.notifications, 1, "offline failure notifies once")
     eq(f.notifications[1].code, "offline", "offline message is explicit")
+end)
+
+test("offline automatic pull schedules a delayed retry", function()
+    local f = fixture({}, {
+        is_online = function() return false end,
+    })
+    f.sync:on_reader_ready()
+    -- Wi-Fi is usually still settling when the open delay expires.
+    f.step()
+    eq(f.sync:status().state, "offline", "automatic pull records offline")
+    eq(#f.queue, 1, "offline automatic pull queues one retry")
+    eq(f.queue[1].delay, PULL_RETRY_DELAY_SECONDS, "retry waits for the link")
+    eq(#f.notifications, 0, "automatic retry stays silent")
+end)
+
+test("automatic pull retries stop at the attempt limit", function()
+    local f = fixture({}, {
+        is_online = function() return false end,
+    })
+    f.sync:on_reader_ready()
+    f.step()
+    eq(#f.queue, 1, "first retry queued")
+    f.step()
+    eq(#f.queue, 1, "second retry queued")
+    f.step()
+    eq(#f.queue, 1, "third retry queued")
+    f.step()
+    eq(#f.queue, 0, "retries stop at the limit")
+    eq(f.sync:status().verified, false, "exhausted retries stay gated")
+end)
+
+test("offline manual sync never schedules a retry", function()
+    local f = fixture({}, {
+        is_online = function() return false end,
+    })
+    eq(f.sync:sync_now(), false, "offline manual sync does not start")
+    eq(#f.queue, 0, "manual path leaves the queue empty")
+    eq(#f.notifications, 1, "manual offline notifies once")
+    eq(f.notifications[1].code, "offline", "offline message is explicit")
+end)
+
+test("retries queued for a closed book never pull again", function()
+    local online_checks = 0
+    local f = fixture({}, {
+        is_online = function()
+            online_checks = online_checks + 1
+            return false
+        end,
+    })
+    f.sync:on_reader_ready()
+    f.step()
+    eq(#f.queue, 1, "retry queued for the open book")
+    f.sync:on_close_document()
+    f.step()
+    eq(online_checks, 1, "stale retry never reaches the offline check")
+    eq(#f.queue, 0, "stale retry does not queue another attempt")
+end)
+
+test("a queued retry verifies once the link comes back", function()
+    local online = false
+    local f = fixture({
+        bookId = "book",
+        progress = 25,
+        chapterUid = 22,
+        chapterIdx = 2,
+        chapterOffset = 150,
+        updateTime = 10,
+    }, {
+        is_online = function() return online end,
+    })
+    f.sync:on_reader_ready()
+    f.step()
+    eq(f.sync:status().verified, false, "offline open leaves the gate closed")
+    online = true
+    f.drain()
+    eq(f.sync:status().verified, true, "retry verifies the reporting gate")
+    eq(#f.choices, 0, "no conflict dialog")
+    eq(#f.notifications, 0, "automatic retry stays silent")
+    local position, reason = f.sync:position_for_report("book")
+    eq(reason, nil, "no gate reason")
+    eq(position.chapter_uid, 22, "live chapter")
 end)
 
 print(string.format(

--- a/weread/lib/progress_sync.lua
+++ b/weread/lib/progress_sync.lua
@@ -7,6 +7,8 @@ ProgressSync.__index = ProgressSync
 
 local OPEN_DELAY_SECONDS = 0.6
 local RESUME_RECHECK_SECONDS = 5 * 60
+local PULL_RETRY_DELAY_SECONDS = 15
+local PULL_MAX_RETRIES = 3
 local BUSY_RETRY_SECONDS = 2
 local BUSY_RETRY_LIMIT = 10
 local SAME_THRESHOLD_PERCENT = 2
@@ -498,6 +500,26 @@ function ProgressSync:_resolve(local_position, remote, context, options)
     end
 end
 
+function ProgressSync:_schedule_pull_retry(options)
+    local attempt = (options.retry or 0) + 1
+    if attempt > PULL_MAX_RETRIES then
+        log("warn", "pull retries exhausted:",
+            "book=", tostring(self.current_book_id))
+        return false
+    end
+    local generation = self.generation
+    self.scheduler:scheduleIn(PULL_RETRY_DELAY_SECONDS, function()
+        if generation ~= self.generation then return end
+        if self.verified or self.pulling then return end
+        self:_pull({ manual = false, retry = attempt })
+    end)
+    log("info", "pull retry scheduled:",
+        "book=", tostring(self.current_book_id),
+        "attempt=", tostring(attempt),
+        "delay=", tostring(PULL_RETRY_DELAY_SECONDS))
+    return true
+end
+
 function ProgressSync:_pull(options)
     options = options or {}
     if self.pulling then return false end
@@ -519,7 +541,11 @@ function ProgressSync:_pull(options)
     end
     if not self.is_online() then
         self.state = "offline"
-        if options.manual then self.notify("offline", {}) end
+        if options.manual then
+            self.notify("offline", {})
+        else
+            self:_schedule_pull_retry(options)
+        end
         return false
     end
 


### PR DESCRIPTION
## 变更说明

修复自动进度拉取在网络未就绪时静默失败，导致阅读时长上报被永久卡死的问题。

打开文档时 `ProgressSync` 会无条件把 `verified` 置为 false，并在 `OPEN_DELAY_SECONDS`（0.6 秒）后调度一次自动 `_pull` 拉取远端进度做比对，比对通过才 `_mark_verified` 打开闸门。

但 `_pull` 的离线分支原本是裸 `return false`，没有任何重试。在 Kindle 等设备上，从休眠唤醒或刚打开书时 Wi-Fi 链路通常还需要 3 到 10 秒才就绪，0.6 秒时 `is_online()` 必然为假，这次自动拉取静默失败后再无人重试，`verified` 就永久停在 false。

后果是阅读时长上报被完全卡死：`position_for_report()` 返回 `progress_unverified`，`read_report.lua` 的 `_precheck` 每一轮都被拦下，而且走的是 `_log_skip` 而非 `_set_error`，所以「上报状态」面板上既不涨次数也不显示任何错误，用户很难判断问题出在哪里。唯一的补救方式是手动点「立即同步进度」，且每次开关书或唤醒后都要重新点一次。

本 PR 让自动触发的 `_pull` 在离线时最多重试 `PULL_MAX_RETRIES`（3）次，间隔 `PULL_RETRY_DELAY_SECONDS`（15 秒），覆盖窗口约 45 秒。每个重试回调在以下任一情况下提前返回：`generation` 已变化（换书或关书）、已有 pull 正在进行、闸门已经验证通过。手动路径行为完全不变，仍然立即通知用户而不是静默重试。

补充一点供维护者判断：`on_resume()` 同样调用 `_pull({ manual = false })`，因此现在也会继承重试，这正好覆盖唤醒场景。但 `generation` 在 resume 时不变，所以频繁 suspend/resume 可能同时排队多条重试链。每条链仍受 3 次上限约束，且任一链验证成功后其余回调都会在 `verified` 判断处短路，最坏情况只是几个空回调，因此本 PR 未额外收敛。如果希望更严格，可以在 `on_resume` 里也推进 `generation`。

## 类型

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Bugfix 要求

修复前的清晰复现步骤：

1. 在 `设置 → 进度管理` 中开启「打开时拉取进度」。
2. 开启 `阅读时间上报`，目标书籍选择「自动关联微信读书书籍」。
3. 让设备休眠超过 5 分钟。
4. 唤醒设备后立即打开一本从书架下载的微信读书书籍，此时 Wi-Fi 仍在重连。
5. 观察 `阅读时间上报 → 上报状态`：上报次数始终为 0，且没有任何错误提示。
6. 手动点击「立即同步进度」，上报立刻恢复正常，次数开始增长。

相关背景：#13 中多位用户报告「上报成功但阅读时间不增加」，并发现「在书架里加载一下章节目录再回阅读界面」可以让时长同步。该偏方本质上就是手动补上了这里缺失的一次进度验证。本 PR 不声明修复该 issue，因为它已关闭且症状不完全重合。

## Feature 要求

不适用，本 PR 是 bugfix。

## 测试

- [x] 已在 KOReader 中手动测试
- [x] 已运行 `bash scripts/run_lua_specs.sh`
- [x] 已运行 `bash scripts/check_lua_namespace.sh`
- [x] 已运行 `luacheck main.lua _meta.lua weread spec`
- [ ] 如涉及插件加载/KOReader 兼容性，已运行或触发 `KOReader integration`
- [ ] 不适用，仅文档或注释变更

测试说明:

```text
自动化测试：spec/progress_sync_spec.lua 新增 5 个回归用例，覆盖
1) 离线自动拉取会排入一次延后重试，且保持静默不打扰用户
2) 重试在 PULL_MAX_RETRIES 上限处停止，不会无限排队
3) 手动拉取在离线时不重试，仍然只发一次 offline 通知
4) generation 变化后已排队的重试不会真正执行，通过计数器确认回调未触达 is_online()
5) 链路恢复后重试成功验证，position_for_report 不再返回 progress_unverified

为确认新用例不是空转断言，曾临时回退模块改动，验证用例会失败
（queues one retry: got 0, want 1），随后立即还原。
progress_sync_spec 检查数从 55 增加到 79，全部 44 个 spec 通过。

luacheck：0 warnings / 0 errors in 100 files。

未做设备手测：该问题的触发依赖真实 Wi-Fi 重连时序，已在 fixture 中通过
可控的 is_online 与调度队列完整模拟。改动仅涉及内部状态机，不触及插件
加载与 KOReader API，故未运行 KOReader integration。
```

## 非公开 WeRead API

- [x] 不涉及非公开 WeRead API
- [ ] 已新增或更新可复现的 Python 验证脚本

## 模块结构

改动仅修改既有文件 `weread/lib/progress_sync.lua`，未新增或移动任何模块，命名空间不受影响。

## 截图

不适用，本 PR 不涉及 UI、菜单、弹窗或交互变更。

## Checklist

- [x] 我已经说明这个 PR 解决的问题或新增的特性。
- [x] 如果是 bugfix，我已经提供复现步骤或关联 issue。
- [x] 如果是新增 UI/交互特性，我已经提供截图或录屏。
- [x] 我没有提交 KOReader `settings/weread.lua`、API key、cookie、token、`x-wrpa-*` 或私人书籍内容。
- [x] 新增或移动的项目 Lua 模块遵循 `weread/lib/`、`weread/ui/` 命名空间规范。
- [x] 新增或修复的逻辑包含对应回归测试；若无法自动化，已在测试说明中解释原因。
- [x] 如果修改了用户可见文本，我已经更新 `weread/lib/i18n.lua`。
- [x] 如果修改了菜单结构，我已经同步更新 README 菜单结构。
- [x] 如果涉及非公开 WeRead Web API，我已经在 `scripts/` 中提交可独立运行、可复现的 Python 验证脚本，并填写了复现命令和脱敏结果。
