### PR TITLE
fix(footnotes): stop ancestor blocks from poisoning note definitions

### DIFF
--- a/spec/footnotes_spec.lua
+++ b/spec/footnotes_spec.lua
@@ -6,6 +6,17 @@ local function expect(condition, message)
     if not condition then error(message or ("check " .. checks .. " failed")) end
 end
 
+-- Plain-find occurrence counter: keeps literal data out of Lua patterns.
+local function count_occurrences(haystack, needle)
+    local count, pos = 0, 1
+    while true do
+        local at = haystack:find(needle, pos, true)
+        if not at then return count end
+        count = count + 1
+        pos = at + #needle
+    end
+end
+
 package.preload["logger"] = function()
     return {
         info = function() end,
@@ -170,5 +181,85 @@ local invalid = transformed:gsub('id="wrfn%-101%-1"', 'id="removed"')
 local valid, validation_error = Footnotes.validate(invalid)
 expect(valid == false and tostring(validation_error):find("missing", 1, true),
     "missing generated target was not rejected")
+
+-- Regression: a chapter-root wrapper block spanning nearly the whole chapter
+-- used to index every descendant anchor with the entire flattened chapter
+-- (both dual-language variants concatenated) as the note text.
+local padding_unit = "這是用來模擬整章長度的填充正文段落。"
+local padding = padding_unit:rep(260)
+local poisoned_html = [[
+<html><body><div id="root">
+<h2 class="wr-traditional">第一章</h2><h2 class="wr-simplified">第一章</h2>
+<p class="wr-traditional">這是正文內容。<a href="#fn_1">1</a></p>
+<p class="wr-simplified">这是正文内容。</p>
+<p class="wr-traditional">]] .. padding .. [[</p>
+<a id="fn_1"></a><p>譯註：這是真正的注釋。</p>
+</div></body></html>
+]]
+local poisoned_scan = Footnotes.scan_chapter(poisoned_html, chapter)
+expect(poisoned_scan.definitions["fn_1"] ~= nil,
+    "real footnote definition was lost to root-block poisoning")
+expect(poisoned_scan.definitions["fn_1"].text == "譯註：這是真正的注釋。",
+    "chapter-root wrapper poisoned the footnote definition text")
+local poisoned_body, poisoned_stats = Footnotes.transform_chapter(
+    poisoned_html, poisoned_scan,
+    Footnotes.build_book_index({ ["101"] = poisoned_scan }, { chapter }))
+expect(poisoned_stats.converted == 1 and poisoned_stats.unresolved == 0,
+    "poisoned-chapter footnote was not converted")
+expect(select(2, poisoned_body:gsub('class="wr%-book%-footnote"', "")) == 1,
+    "root-block poisoning generated spurious footnote asides")
+local poisoned_notes = poisoned_body:match('<div class="wr%-footnotes">.*')
+expect(poisoned_notes and poisoned_notes:find("譯註：這是真正的注釋。", 1, true),
+    "converted note did not embed the true footnote text")
+expect(poisoned_notes and not poisoned_notes:find(padding_unit, 1, true),
+    "generated footnote embedded flattened chapter padding")
+expect(count_occurrences(poisoned_body, padding) == 1,
+    "generated footnotes duplicated chapter body padding")
+
+-- Shortest-wins: when an oversized-but-legitimate ancestor capture is recorded
+-- first, the smaller direct capture must replace it.
+local filler = "補充背景說明文字。"
+local wrapped_html = "<aside>"
+    .. filler:rep(30) .. '<p id="short-note">真注釋</p>' .. filler:rep(30)
+    .. "</aside>"
+local wrapped_scan = Footnotes.scan_chapter(wrapped_html, chapter)
+expect(wrapped_scan.definitions["short-note"] ~= nil,
+    "wrapped short note definition was not indexed")
+expect(wrapped_scan.definitions["short-note"].text == "真注釋",
+    "larger ancestor capture was not replaced by the shorter direct capture")
+
+-- A long but legitimate note below the size cap must survive intact.
+local long_text = string.rep("這是一條很長但完全真實的注釋內容。", 100)
+local long_scan = Footnotes.scan_chapter(
+    '<p id="long-note">' .. long_text .. "</p>", chapter)
+expect(long_scan.definitions["long-note"] ~= nil,
+    "long legitimate note definition was dropped")
+expect(long_scan.definitions["long-note"].text == long_text,
+    "long legitimate note text was truncated or altered")
+
+-- Regression: a backlink arrow inside an element sharing the note target's id
+-- used to poison the definition, since shortest-wins favored its 3-byte glyph.
+local arrow_html = [[<li id="fn_9">這是完整的注釋正文內容。<a id="fn_9" href="#ref_9">↩</a></li>]]
+local arrow_doc = [[<p>正文<a class="noteref" href="#fn_9"><sup>[9]</sup></a></p>]] .. arrow_html
+local arrow_scan = Footnotes.scan_chapter(arrow_doc, chapter)
+expect(arrow_scan.definitions["fn_9"] ~= nil,
+    "backlink arrow eliminated the footnote definition entirely")
+-- The stored text is the enclosing li capture; strip_tags leaves the trailing
+-- return glyph in place, but the definition must never collapse to it.
+expect(arrow_scan.definitions["fn_9"].text == "這是完整的注釋正文內容。 ↩",
+    "backlink arrow was stored as the footnote definition text")
+local arrow_body, arrow_stats = Footnotes.transform_chapter(
+    arrow_doc, arrow_scan,
+    Footnotes.build_book_index({ ["101"] = arrow_scan }, { chapter }))
+expect(arrow_stats.converted == 1 and arrow_stats.unresolved == 0,
+    "note sharing its id with a backlink arrow was not converted")
+expect(Footnotes.validate(arrow_body) == true,
+    "arrow-poisoned chapter generated invalid footnote markup")
+local arrow_aside = arrow_body:match(
+    'class="wr%-book%-footnote".-<a href="#wrfnref%-101%-1"[^>]*>%[9%]</a>(.-)</p>')
+expect(arrow_aside and arrow_aside:find("這是完整的注釋正文內容。", 1, true),
+    "generated aside did not embed the full footnote text")
+expect(arrow_aside and arrow_aside:match("^%s*↩%s*$") == nil,
+    "generated aside collapsed to the bare backlink arrow")
 
 print(("footnotes_spec: %d checks"):format(checks))

--- a/spec/footnotes_spec.lua
+++ b/spec/footnotes_spec.lua
@@ -262,4 +262,37 @@ expect(arrow_aside and arrow_aside:find("這是完整的注釋正文內容。", 
 expect(arrow_aside and arrow_aside:match("^%s*↩%s*$") == nil,
     "generated aside collapsed to the bare backlink arrow")
 
+-- Regression: notes written only in kana, hangul, Cyrillic or astral-plane CJK
+-- were treated as pure symbols, since the old check only knew %w and the CJK
+-- UTF-8 lead bytes 0xE4-0xE9. Any real text codepoint must keep the candidate.
+local scripts_html = '<p id="kana-note">これは日本語の脚注です。</p>'
+    .. '<p id="hangul-note">한국어 각주입니다.</p>'
+    .. '<p id="cyrillic-note">Это сноска на русском языке.</p>'
+    .. '<p id="extb-note">𠀀𠀁 rare CJK extension footnote.</p>'
+    .. '<p id="mixed-note">①これは注釈本体。</p>'
+local scripts_scan = Footnotes.scan_chapter(scripts_html, chapter)
+for _, anchor in ipairs({ "kana-note", "hangul-note", "cyrillic-note",
+    "extb-note", "mixed-note" }) do
+    expect(scripts_scan.definitions[anchor] ~= nil,
+        "non-ASCII script footnote was mistaken for a pure symbol: " .. anchor)
+end
+expect(scripts_scan.definitions["kana-note"].text == "これは日本語の脚注です。",
+    "kana-only footnote text was not stored verbatim")
+expect(scripts_scan.definitions["mixed-note"].text == "①これは注釈本体。",
+    "marker-plus-text footnote text was not stored verbatim")
+
+-- Symbol-only candidates (backlink arrows and their variation selectors,
+-- enclosed numbers, CJK/Latin-1 punctuation) must still be rejected outright.
+local glyph_html = '<p id="glyph-arrow">↩</p><p id="glyph-arrow-vs">↩️</p>'
+    .. '<p id="glyph-left">←</p><p id="glyph-hook">⤴</p>'
+    .. '<p id="glyph-enclosed">①</p><p id="glyph-cjk-punct">。</p>'
+    .. '<p id="glyph-latin1">«»</p><p id="glyph-dash">……</p>'
+local glyph_scan = Footnotes.scan_chapter(glyph_html, chapter)
+for _, anchor in ipairs({ "glyph-arrow", "glyph-arrow-vs", "glyph-left",
+    "glyph-hook", "glyph-enclosed", "glyph-cjk-punct", "glyph-latin1",
+    "glyph-dash" }) do
+    expect(glyph_scan.definitions[anchor] == nil,
+        "symbol-only candidate was stored as note text: " .. anchor)
+end
+
 print(("footnotes_spec: %d checks"):format(checks))

--- a/weread/lib/footnotes.lua
+++ b/weread/lib/footnotes.lua
@@ -96,6 +96,20 @@ local function is_trivial_note(value)
         or is_symbol_marker(text)
 end
 
+-- Backlink glyphs (↩ ↑ ← ⤴) are pure symbols, yet an element carrying one may
+-- share the note target's id; a real note always contains words or CJK text,
+-- so candidates with neither can never be definitions.
+local function has_word_or_cjk_char(text)
+    if text:find("%w") then return true end
+    for i = 1, #text do
+        local byte = text:byte(i)
+        -- UTF-8 lead bytes 0xE4-0xE9 cover CJK Unified Ideographs U+4E00-U+9FFF
+        -- and neighboring CJK blocks.
+        if byte >= 228 and byte <= 233 then return true end
+    end
+    return false
+end
+
 local function normalize_path(value)
     value = decode_entities(value):gsub("\\", "/")
     value = value:match("^%s*(.-)%s*$") or ""
@@ -205,10 +219,27 @@ end
 
 local BLOCK_TAGS = { "aside", "li", "p", "div", "section", "blockquote", "dd", "td" }
 
+-- Cap on cleaned note text length in bytes (#text counts bytes, so this is
+-- ~2000 CJK chars); genuine notes are far smaller, whole-chapter captures are
+-- far larger.
+local MAX_NOTE_TEXT_BYTES = 6000
+
 local function remember_definition(definitions, anchor, inner)
-    if not anchor or anchor == "" or definitions[anchor] then return end
+    if not anchor or anchor == "" then return end
     local text = clean_note_text(inner)
-    if text ~= "" and not is_trivial_note(text) then
+    if text == "" or is_trivial_note(text) then return end
+    if not has_word_or_cjk_char(text) then return end
+    -- Ancestor blocks spanning most of the chapter poison the definition;
+    -- reject oversized candidates outright instead of storing them.
+    if #text > MAX_NOTE_TEXT_BYTES then
+        logger.warn("dropping oversized note candidate:",
+            "anchor=", tostring(anchor), "bytes=", tostring(#text))
+        return
+    end
+    local current = definitions[anchor]
+    -- The true note content is the smallest region describing the anchor,
+    -- so keep whichever candidate has the shortest cleaned text.
+    if not current or #text < #current.text then
         definitions[anchor] = { text = text }
     end
 end

--- a/weread/lib/footnotes.lua
+++ b/weread/lib/footnotes.lua
@@ -96,18 +96,53 @@ local function is_trivial_note(value)
         or is_symbol_marker(text)
 end
 
--- Backlink glyphs (↩ ↑ ← ⤴) are pure symbols, yet an element carrying one may
--- share the note target's id; a real note always contains words or CJK text,
--- so candidates with neither can never be definitions.
-local function has_word_or_cjk_char(text)
-    if text:find("%w") then return true end
-    for i = 1, #text do
-        local byte = text:byte(i)
-        -- UTF-8 lead bytes 0xE4-0xE9 cover CJK Unified Ideographs U+4E00-U+9FFF
-        -- and neighboring CJK blocks.
-        if byte >= 228 and byte <= 233 then return true end
+-- Decode the UTF-8 codepoint starting at byte i; returns the codepoint (nil
+-- for a malformed sequence) and the number of bytes consumed.
+local function utf8_codepoint(text, i)
+    local b = text:byte(i)
+    if b < 0x80 then return b, 1 end
+    local cp, len
+    if b >= 0xC2 and b < 0xE0 then cp, len = b - 0xC0, 2
+    elseif b >= 0xE0 and b < 0xF0 then cp, len = b - 0xE0, 3
+    elseif b >= 0xF0 and b < 0xF5 then cp, len = b - 0xF0, 4
+    else return nil, 1 end
+    for j = 1, len - 1 do
+        local cb = text:byte(i + j)
+        if not cb or cb < 0x80 or cb > 0xBF then return nil, j end
+        cp = cp * 64 + (cb - 0x80)
     end
-    return false
+    return cp, len
+end
+
+-- Backlink glyphs (↩ ↑ ← ⤴) are pure symbols, yet an element carrying one may
+-- share the note target's id; such a capture can never be a definition.
+-- Enumerating "known" text scripts instead (the old %w + CJK lead-byte check)
+-- silently dropped notes written only in kana, hangul, Cyrillic or any other
+-- non-ASCII script, so reject a candidate only when EVERY codepoint it holds
+-- is a symbol or punctuation: arrows, dingbats and enclosed numbers
+-- (U+2000-U+2FFF), CJK punctuation (U+3000-U+303F), Latin-1 symbols
+-- (U+0080-U+00BF), variation selectors and the BOM. Any other codepoint
+-- (Latin letters, kana, hangul, CJK, emoji …) counts as note text.
+local function is_symbol_only(text)
+    local i, n = 1, #text
+    while i <= n do
+        local cp, len = utf8_codepoint(text, i)
+        if not cp then
+            i = i + (len or 1)
+        elseif cp < 128 then
+            if text:sub(i, i):match("%w") then return false end
+            i = i + 1
+        elseif (cp >= 0x80 and cp <= 0xBF)
+            or (cp >= 0x2000 and cp <= 0x2FFF)
+            or (cp >= 0x3000 and cp <= 0x303F)
+            or (cp >= 0xFE00 and cp <= 0xFE0F)
+            or cp == 0xFEFF then
+            i = i + len
+        else
+            return false
+        end
+    end
+    return true
 end
 
 local function normalize_path(value)
@@ -228,7 +263,7 @@ local function remember_definition(definitions, anchor, inner)
     if not anchor or anchor == "" then return end
     local text = clean_note_text(inner)
     if text == "" or is_trivial_note(text) then return end
-    if not has_word_or_cjk_char(text) then return end
+    if is_symbol_only(text) then return end
     -- Ancestor blocks spanning most of the chapter poison the definition;
     -- reject oversized candidates outright instead of storing them.
     if #text > MAX_NOTE_TEXT_BYTES then


### PR DESCRIPTION
## 变更说明

修复繁简双语书籍中脚注定义被祖先块污染的缺陷。`collect_definitions()` 会把整章正文误存为单条脚注定义，导致在 KOReader 默认的页内脚注流中，每个脚注标记都渲染出一大段拍平的章节正文，读者看到大量重复文字。

相关：#137（调试同一本书时发现的 `font-size: 0` 根字号问题，已另开 PR）。

## 类型

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Bugfix 要求

无关联 issue（上游此前无人报告过此问题），提供复现步骤。

复现步骤（修复前）：

1. 用插件下载一本繁简合排的双语 EPUB。实测书目：《天才的責任：維根斯坦傳》繁简版
2. 在 KOReader 中打开该书，保持默认的页内脚注（in-page footnote）显示方式
3. 翻到任意带脚注标记的正文页并触发脚注
4. 现象：脚注展开的不是注释本身，而是整章正文（繁简两个版本被 `clean_note_text` 拼接在一起），页面上出现大段重复文字

实测环境：KOReader v2026.07.1，Kindle。

根因：

`collect_definitions()` 遍历 BLOCK_TAGS 时，对每个匹配到的外层块，会用**外层块的内部文本**去记录其下所有带 id 的**后代**标签。在繁简双语章节中，章节根级 wrapper 几乎覆盖整章，同时包含正文锚点与章末注释，于是每个脚注锚点都被索引成了整章拍平文本。先到先得的守卫（`definitions[anchor]`）让问题进一步恶化：一旦被污染的祖先捕获先于真正的定义块被记录，正确的短文本就再也无法替换它。

实测数据（受影响书籍）：生成 606 条 aside，其中 60 条为被污染的巨型条目，最长约 53500 字符，而正常注释的中位长度约 130 字符。

修复：

`remember_definition()` 现在会：

- 直接拒绝超过 `MAX_NOTE_TEXT_BYTES`（6000 字节，约 2000 个中日韩字符）的候选，并记录一条警告日志。真实注释远低于此阈值，整章捕获远高于此阈值
- 每个锚点保留**最短**候选而非先到先得。真正的注释是描述该锚点的最小区域，祖先捕获必然是它的严格超集
- 拒绝纯符号候选，使共用同一 id 的回链字形（如 `↩`）无法顶替真实注释文本

## Feature 要求

不适用，本 PR 为 bugfix，未新增特性。

## 测试

- [x] 已在 KOReader 中手动测试
- [x] 已运行 `bash scripts/run_lua_specs.sh`
- [x] 已运行 `bash scripts/check_lua_namespace.sh`
- [x] 已运行 `luacheck main.lua _meta.lua weread spec`
- [ ] 如涉及插件加载/KOReader 兼容性，已运行或触发 `KOReader integration`
- [ ] 不适用，仅文档或注释变更

测试说明:

```text
新增回归 spec（spec/footnotes_spec.lua，+91）覆盖四种情形：
1. 章节根级 wrapper 污染
2. 阈值之下最短候选优先
3. 长但合法的注释被保留（约 1300 个中日韩字符）
4. 纯箭头符号候选被拒绝

已验证这些新 spec 在修复前的代码上失败、修复后通过。
全套 45 个 Lua spec 通过；check_lua_namespace.sh 无告警；
luacheck main.lua _meta.lua weread spec 无告警。

未触发 KOReader integration 工作流：本 PR 只改动 footnotes.lua 内部的
定义收集逻辑，不涉及插件加载路径或 KOReader 兼容性。

设备侧已手动验证：修复后该书正文 4117 段、470866 个可见字符零丢失，
重复文字现象消失。
```

## 非公开 WeRead API

- [x] 不涉及非公开 WeRead API
- [ ] 已新增或更新可复现的 Python 验证脚本

脚本路径:

```text
不适用
```

复现命令与脱敏结果:

```text
不适用。本 PR 只修改本地 HTML 解析阶段的脚注定义收集逻辑，
未新增或修改任何 WeRead Web API 调用。
```

## 模块结构

未新增或移动任何模块。仅修改既有的 `weread/lib/footnotes.lua`，并新增 `spec/footnotes_spec.lua`。命名空间保持不变，未引入根级 `lib/`、`ui/` 模块，也未引入裸 `lib.*`、`ui.*` 模块键。

## 截图

不适用。本 PR 是渲染缺陷修复，未新增或修改 UI、菜单、弹窗与交互。

## Checklist

- [x] 我已经说明这个 PR 解决的问题或新增的特性。
- [x] 如果是 bugfix，我已经提供复现步骤或关联 issue。
- [x] 如果是新增 UI/交互特性，我已经提供截图或录屏。（不适用：未新增 UI 或交互特性）
- [x] 我没有提交 KOReader `settings/weread.lua`、API key、cookie、token、`x-wrpa-*` 或私人书籍内容。
- [x] 新增或移动的项目 Lua 模块遵循 `weread/lib/`、`weread/ui/` 命名空间规范。（不适用：未新增或移动模块）
- [x] 新增或修复的逻辑包含对应回归测试；若无法自动化，已在测试说明中解释原因。
- [x] 如果修改了用户可见文本，我已经更新 `weread/lib/i18n.lua`。（不适用：未修改用户可见文本）
- [x] 如果修改了菜单结构，我已经同步更新 README 菜单结构。（不适用：未修改菜单结构）
- [x] 如果涉及非公开 WeRead Web API，我已经在 `scripts/` 中提交可独立运行、可复现的 Python 验证脚本，并填写了复现命令和脱敏结果。（不适用：不涉及）
