### PR TITLE
fix(content): sanitize hostile font-size:0 in server book css

### DIFF
--- a/spec/content_css_sanitize_spec.lua
+++ b/spec/content_css_sanitize_spec.lua
@@ -44,10 +44,12 @@ expect(count == 0 and cleaned == ".slide-nav { font-size: 0 }",
     "an inline-block whitespace trick on a class selector was stripped")
 
 cleaned, count = Content.sanitize_book_css("body p{font-size:0}")
-expect(count == 0, "a descendant-of-body selector was treated as the root element")
+expect(count == 0 and cleaned == "body p{font-size:0}",
+    "a descendant-of-body selector was treated as the root element")
 
 cleaned, count = Content.sanitize_book_css("body,.wrapper{font-size:0}")
-expect(count == 0, "a selector list mixing body with other targets was treated as root-only")
+expect(count == 0 and cleaned == "body,.wrapper{font-size:0}",
+    "a selector list mixing body with other targets was treated as root-only")
 
 cleaned, count = Content.sanitize_book_css("HTML ,\nBODY { font-size: 0 }")
 expect(count == 1 and not cleaned:find("font%-size"),

--- a/spec/content_css_sanitize_spec.lua
+++ b/spec/content_css_sanitize_spec.lua
@@ -32,28 +32,61 @@ expect(cleaned:find("{", 1, true) and cleaned:find("}", 1, true),
 expect(cleaned:find("margin: 0;", 1, true) and cleaned:find("padding: 0;", 1, true),
     "sibling margin/padding declarations must survive sanitization")
 
+-- Review: `font-size: 0` can be intentional outside the root elements (e.g.
+-- hiding whitespace between inline-block items), so only rules whose selector
+-- list names exactly html/body may be touched.
 cleaned, count = Content.sanitize_book_css(".a{font-size: 0 !important;color:red}")
-expect(count == 1 and not cleaned:find("font%-size"),
-    "!important zero font-size was not removed")
-expect(cleaned:find("color:red", 1, true),
-    "declaration after the removed !important rule was damaged")
+expect(count == 0 and cleaned == ".a{font-size: 0 !important;color:red}",
+    "a non-root selector had its intentional font-size:0 removed")
 
-cleaned, count = Content.sanitize_book_css("p{font-size: 0px}h1{font-size: 0%;}")
+cleaned, count = Content.sanitize_book_css(".slide-nav { font-size: 0 }")
+expect(count == 0 and cleaned == ".slide-nav { font-size: 0 }",
+    "an inline-block whitespace trick on a class selector was stripped")
+
+cleaned, count = Content.sanitize_book_css("body p{font-size:0}")
+expect(count == 0, "a descendant-of-body selector was treated as the root element")
+
+cleaned, count = Content.sanitize_book_css("body,.wrapper{font-size:0}")
+expect(count == 0, "a selector list mixing body with other targets was treated as root-only")
+
+cleaned, count = Content.sanitize_book_css("HTML ,\nBODY { font-size: 0 }")
+expect(count == 1 and not cleaned:find("font%-size"),
+    "root selector matching must be case- and whitespace-insensitive")
+
+-- Deliberate limits: :root and @media-wrapped root rules stay untouched.
+cleaned, count = Content.sanitize_book_css(":root{font-size:0}")
+expect(count == 0 and cleaned == ":root{font-size:0}",
+    ":root sizing was stripped although only html/body rules are covered")
+
+local media_css = "@media print { html, body { font-size: 0 } }"
+cleaned, count = Content.sanitize_book_css(media_css)
+expect(count == 0 and cleaned == media_css,
+    "@media-wrapped root sizing was stripped although only top-level rules are covered")
+
+-- An at-rule before the selector must not prevent matching the rule itself.
+cleaned, count = Content.sanitize_book_css('@charset "utf-8";html,body{font-size:0}')
+expect(count == 1 and not cleaned:find("font%-size"),
+    "a preceding at-rule broke root-selector matching")
+
+cleaned, count = Content.sanitize_book_css("html{font-size: 0px}body{font-size: 0%;}")
 expect(count == 2 and not cleaned:find("font%-size"),
-    "zero font-size with px/% units was not fully removed")
+    "zero font-size with px/% units was not fully removed on root selectors")
 
 cleaned, count = Content.sanitize_book_css(".fs05 { font-size: 0.5rem; }")
 expect(count == 0 and cleaned == ".fs05 { font-size: 0.5rem; }",
     "fractional font-size must stay untouched")
+
+cleaned, count = Content.sanitize_book_css("html, body { font-size: 0.5rem; }")
+expect(count == 0 and cleaned == "html, body { font-size: 0.5rem; }",
+    "fractional root font-size must stay untouched")
 
 cleaned, count = Content.sanitize_book_css("p { font-size: 1rem; }")
 expect(count == 0 and cleaned == "p { font-size: 1rem; }",
     "non-zero font-size must stay untouched")
 
 cleaned, count = Content.sanitize_book_css("{ color: #000; font-size: 0\n}")
-expect(count == 1, "trailing font-size:0 without semicolon was not detected")
-expect(cleaned:sub(-1) == "}", "removal must keep the closing brace of the block")
-expect(cleaned:find("color: #000;", 1, true), "sibling color declaration was damaged")
+expect(count == 0 and cleaned:find("font-size: 0", 1, true),
+    "a block without a selector must be left untouched")
 
 local passthrough, passthrough_count = Content.sanitize_book_css(nil)
 expect(passthrough == nil and passthrough_count == 0,
@@ -63,6 +96,7 @@ expect(passthrough == "" and passthrough_count == 0,
     "empty input must pass through unchanged with count 0")
 
 -- Integration-style: sanitizing an already-sanitized shard changes nothing.
+-- Only the root rule qualifies; the other blocks keep their declarations.
 local combined = table.concat({
     hostile,
     ".a{font-size: 0 !important;color:red}",
@@ -71,17 +105,17 @@ local combined = table.concat({
 }, "\n")
 local once, first_count = Content.sanitize_book_css(combined)
 local twice, second_count = Content.sanitize_book_css(once)
-expect(first_count == 5, "combined shard should lose five zero font-size declarations")
+expect(first_count == 1, "combined shard should lose only the root font-size declaration")
 expect(second_count == 0 and twice == once, "sanitization must be idempotent")
 
 -- Adjacent zero declarations: each pass consumes one boundary character, so
 -- the sanitizer must iterate to a fixpoint instead of keeping the second one.
-cleaned, count = Content.sanitize_book_css("p{font-size:0;font-size:0}")
+cleaned, count = Content.sanitize_book_css("html,body{font-size:0;font-size:0}")
 expect(count == 2, "adjacent zero declarations must both be removed")
 expect(not cleaned:find("font%-size"), "adjacent removal left a hostile declaration behind")
-expect(cleaned:find("^p%{.*%}$"), "block structure was damaged by adjacent removal")
+expect(cleaned:find("^html,body%{.*%}$"), "block structure was damaged by adjacent removal")
 
-cleaned, count = Content.sanitize_book_css("p{font-size:0 ;font-size:0 ;color:red}")
+cleaned, count = Content.sanitize_book_css("html,body{font-size:0 ;font-size:0 ;color:red}")
 expect(count == 2 and cleaned:find("color:red", 1, true),
     "spaced adjacent zeros must be removed while siblings survive")
 
@@ -91,11 +125,11 @@ expect(count == 1 and not cleaned:find("font%-size"),
 
 -- A CSS comment carrying the exact declaration may lose its interior, but the
 -- stylesheet structure around it must survive and the result stays idempotent.
-local commented = "p{ /* font-size: 0 ; old */ color:blue }"
+local commented = "body{ /* font-size: 0 ; old */ color:blue }"
 cleaned, count = Content.sanitize_book_css(commented)
 local open_braces = select(2, cleaned:gsub("%{", ""))
 local close_braces = select(2, cleaned:gsub("}", ""))
-expect(cleaned:find("color:blue", 1, true) and open_braces == close_braces,
+expect(count == 1 and cleaned:find("color:blue", 1, true) and open_braces == close_braces,
     "comment rewrite must keep the block structurally valid")
 local _, recount = Content.sanitize_book_css(cleaned)
 expect(recount == 0, "sanitization after comment rewrite must be idempotent")

--- a/spec/content_css_sanitize_spec.lua
+++ b/spec/content_css_sanitize_spec.lua
@@ -1,0 +1,103 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local checks = 0
+local function expect(condition, message)
+    checks = checks + 1
+    if not condition then error(message or ("check " .. checks .. " failed")) end
+end
+
+package.preload["logger"] = function()
+    return {
+        info = function() end,
+        warn = function() end,
+        err = function() end,
+        dbg = function() end,
+    }
+end
+package.preload["weread.lib.crypto"] = function() return {} end
+package.preload["weread.lib.reader_state"] = function() return {} end
+package.preload["weread.lib.protocol"] = function() return {} end
+package.preload["weread.lib.thoughts"] = function() return {} end
+
+local Content = require("weread/lib/content")
+
+-- The hostile rule observed in real WeRead e_2 shards: crengine honors the
+-- root-element zero sizing and p{font-size:1rem} then collapses the whole book.
+local hostile = "html,\nbody {\n  margin: 0;\n  padding: 0;\n  font-size: 0;\n  }"
+local cleaned, count = Content.sanitize_book_css(hostile)
+expect(count == 1, "the single font-size:0 declaration must be reported as one removal")
+expect(not cleaned:find("font%-size"), "font-size:0 declaration survived sanitization")
+expect(cleaned:find("{", 1, true) and cleaned:find("}", 1, true),
+    "sanitization must keep the rule braces intact")
+expect(cleaned:find("margin: 0;", 1, true) and cleaned:find("padding: 0;", 1, true),
+    "sibling margin/padding declarations must survive sanitization")
+
+cleaned, count = Content.sanitize_book_css(".a{font-size: 0 !important;color:red}")
+expect(count == 1 and not cleaned:find("font%-size"),
+    "!important zero font-size was not removed")
+expect(cleaned:find("color:red", 1, true),
+    "declaration after the removed !important rule was damaged")
+
+cleaned, count = Content.sanitize_book_css("p{font-size: 0px}h1{font-size: 0%;}")
+expect(count == 2 and not cleaned:find("font%-size"),
+    "zero font-size with px/% units was not fully removed")
+
+cleaned, count = Content.sanitize_book_css(".fs05 { font-size: 0.5rem; }")
+expect(count == 0 and cleaned == ".fs05 { font-size: 0.5rem; }",
+    "fractional font-size must stay untouched")
+
+cleaned, count = Content.sanitize_book_css("p { font-size: 1rem; }")
+expect(count == 0 and cleaned == "p { font-size: 1rem; }",
+    "non-zero font-size must stay untouched")
+
+cleaned, count = Content.sanitize_book_css("{ color: #000; font-size: 0\n}")
+expect(count == 1, "trailing font-size:0 without semicolon was not detected")
+expect(cleaned:sub(-1) == "}", "removal must keep the closing brace of the block")
+expect(cleaned:find("color: #000;", 1, true), "sibling color declaration was damaged")
+
+local passthrough, passthrough_count = Content.sanitize_book_css(nil)
+expect(passthrough == nil and passthrough_count == 0,
+    "nil input must pass through unchanged with count 0")
+passthrough, passthrough_count = Content.sanitize_book_css("")
+expect(passthrough == "" and passthrough_count == 0,
+    "empty input must pass through unchanged with count 0")
+
+-- Integration-style: sanitizing an already-sanitized shard changes nothing.
+local combined = table.concat({
+    hostile,
+    ".a{font-size: 0 !important;color:red}",
+    "p{font-size: 0px}h1{font-size: 0%;}",
+    "{ color: #000; font-size: 0\n}",
+}, "\n")
+local once, first_count = Content.sanitize_book_css(combined)
+local twice, second_count = Content.sanitize_book_css(once)
+expect(first_count == 5, "combined shard should lose five zero font-size declarations")
+expect(second_count == 0 and twice == once, "sanitization must be idempotent")
+
+-- Adjacent zero declarations: each pass consumes one boundary character, so
+-- the sanitizer must iterate to a fixpoint instead of keeping the second one.
+cleaned, count = Content.sanitize_book_css("p{font-size:0;font-size:0}")
+expect(count == 2, "adjacent zero declarations must both be removed")
+expect(not cleaned:find("font%-size"), "adjacent removal left a hostile declaration behind")
+expect(cleaned:find("^p%{.*%}$"), "block structure was damaged by adjacent removal")
+
+cleaned, count = Content.sanitize_book_css("p{font-size:0 ;font-size:0 ;color:red}")
+expect(count == 2 and cleaned:find("color:red", 1, true),
+    "spaced adjacent zeros must be removed while siblings survive")
+
+cleaned, count = Content.sanitize_book_css("html,body{font-size:0vh}")
+expect(count == 1 and not cleaned:find("font%-size"),
+    "zero with any letter unit (0vh) is a zero length and must be removed")
+
+-- A CSS comment carrying the exact declaration may lose its interior, but the
+-- stylesheet structure around it must survive and the result stays idempotent.
+local commented = "p{ /* font-size: 0 ; old */ color:blue }"
+cleaned, count = Content.sanitize_book_css(commented)
+local open_braces = select(2, cleaned:gsub("%{", ""))
+local close_braces = select(2, cleaned:gsub("}", ""))
+expect(cleaned:find("color:blue", 1, true) and open_braces == close_braces,
+    "comment rewrite must keep the block structurally valid")
+local _, recount = Content.sanitize_book_css(cleaned)
+expect(recount == 0, "sanitization after comment rewrite must be idempotent")
+
+print(("content_css_sanitize_spec: %d checks"):format(checks))

--- a/weread/lib/content.lua
+++ b/weread/lib/content.lua
@@ -1362,12 +1362,75 @@ function Content.fetch_chapter_xhtml(client, settings, book, chapter)
     )
 end
 
+-- True when the text following the literal "0" of a font-size declaration
+-- (already captured by the caller's pattern) is only an optional unit plus
+-- whitespace and an optional !important flag, i.e. the declared size really is
+-- zero. Zero times any unit is still zero length, so an empty tail (bare 0) and
+-- every letter-unit form (px/em/rem/vh/...) count; fractional sizes such as
+-- 0.5rem never match because "." is not a letter.
+local function is_zero_font_size(tail)
+    local value = tail:lower():match("^%s*(.-)%s*$")
+    if value:sub(-10) == "!important" then
+        value = (value:match("^(.-)%s*!important$") or ""):match("^%s*(.-)%s*$")
+    end
+    return value == "" or value == "%" or value:match("^%a+$") ~= nil
+end
+
+-- Known limitations: property-name matching is case-sensitive (all observed
+-- WeRead shards are lowercase), and a CSS comment containing exactly
+-- "font-size: 0" may have its interior rewritten without structural harm.
+
+-- Strip hostile `font-size: 0` declarations from server-provided book css.
+-- WeRead shards occasionally ship `html, body { ... font-size: 0; }`; WeRead's
+-- own apps ignore root-element sizing but crengine honors it, collapsing the
+-- whole book to a near-zero font size on device.
+local function sanitize_book_css_pass(css)
+    local removed = 0
+    -- The sentinel "{" guarantees the boundary capture below always has a
+    -- character to inspect, even when the declaration opens the stylesheet.
+    local sanitized = ("{" .. css):gsub("([^%w%-])(%s*)font%-size%s*:%s*0([^;}]*)([;}])", function(boundary, leading, tail, terminator)
+        if not is_zero_font_size(tail) then
+            return nil -- keep fractional sizes such as 0.5rem untouched
+        end
+        removed = removed + 1
+        -- The terminator is part of the match: a semicolon belongs to the
+        -- removed declaration, but a block-closing brace must survive it.
+        if terminator == "}" then
+            return boundary .. leading .. "}"
+        end
+        return boundary .. leading
+    end)
+    return sanitized:sub(2), removed
+end
+
+function Content.sanitize_book_css(css)
+    if type(css) ~= "string" or css == "" then
+        return css, 0
+    end
+    -- Each pass consumes one boundary character per match, so adjacent zero
+    -- declarations ("font-size:0;font-size:0") need repeated passes until the
+    -- fixpoint; the cap only guards pathological input.
+    local removed_total = 0
+    local sanitized = css
+    for _i = 1, 16 do
+        local removed
+        sanitized, removed = sanitize_book_css_pass(sanitized)
+        removed_total = removed_total + removed
+        if removed == 0 then break end
+    end
+    return sanitized, removed_total
+end
+
 function Content.fetch_chapter_css(client, settings, book, chapter)
     local ok, css = pcall(function()
         return Content.decode_content_shard(Content.fetch_chapter_shard(client, settings, book, chapter, "/web/book/chapter/e_2"))
     end)
     if ok then
-        return css
+        local sanitized, removed = Content.sanitize_book_css(css)
+        if removed > 0 then
+            logger.warn("removed ", removed, " hostile font-size:0 declarations from book css")
+        end
+        return sanitized
     end
     return nil
 end

--- a/weread/lib/content.lua
+++ b/weread/lib/content.lua
@@ -1377,30 +1377,63 @@ local function is_zero_font_size(tail)
 end
 
 -- Known limitations: property-name matching is case-sensitive (all observed
--- WeRead shards are lowercase), and a CSS comment containing exactly
--- "font-size: 0" may have its interior rewritten without structural harm.
+-- WeRead shards are lowercase), a CSS comment containing exactly
+-- "font-size: 0" may have its interior rewritten without structural harm, and
+-- only top-level rules naming exactly html/body are touched (:root,
+-- descendant selectors and @media-wrapped rules are left as-is).
 
--- Strip hostile `font-size: 0` declarations from server-provided book css.
--- WeRead shards occasionally ship `html, body { ... font-size: 0; }`; WeRead's
--- own apps ignore root-element sizing but crengine honors it, collapsing the
--- whole book to a near-zero font size on device.
-local function sanitize_book_css_pass(css)
+-- True when the selector list names nothing but the root elements, i.e. every
+-- comma-separated selector is exactly html or body (case- and
+-- whitespace-insensitive). Compound selectors such as "body p" or
+-- "body, .wrapper" also style other content, so they never qualify.
+local function is_root_selector_list(selectors)
+    local count = 0
+    for selector in (selectors or ""):gmatch("[^,]+") do
+        count = count + 1
+        local name = selector:lower():gsub("^%s+", ""):gsub("%s+$", "")
+        if name ~= "html" and name ~= "body" then return false end
+    end
+    return count > 0
+end
+
+-- Remove every zero `font-size` declaration from one braceless declaration
+-- block. The sentinel "{" guarantees the boundary capture below always has a
+-- character to inspect, even when the declaration opens the block.
+local function strip_zero_font_sizes(block)
     local removed = 0
-    -- The sentinel "{" guarantees the boundary capture below always has a
-    -- character to inspect, even when the declaration opens the stylesheet.
-    local sanitized = ("{" .. css):gsub("([^%w%-])(%s*)font%-size%s*:%s*0([^;}]*)([;}])", function(boundary, leading, tail, terminator)
+    local cleaned = ("{" .. block):gsub("([^%w%-])(%s*)font%-size%s*:%s*0([^;}]*)(;?)", function(boundary, leading, tail, _terminator)
         if not is_zero_font_size(tail) then
             return nil -- keep fractional sizes such as 0.5rem untouched
         end
         removed = removed + 1
-        -- The terminator is part of the match: a semicolon belongs to the
-        -- removed declaration, but a block-closing brace must survive it.
-        if terminator == "}" then
-            return boundary .. leading .. "}"
-        end
         return boundary .. leading
     end)
-    return sanitized:sub(2), removed
+    return cleaned:sub(2), removed
+end
+
+-- Strip hostile `font-size: 0` declarations from server-provided book css, but
+-- only inside rules whose selector list is exactly `html` and/or `body`.
+-- WeRead shards occasionally ship `html, body { ... font-size: 0; }`; WeRead's
+-- own apps ignore root-element sizing but crengine honors it, collapsing the
+-- whole book to a near-zero font size on device. Elsewhere `font-size: 0` can
+-- be intentional (e.g. hiding whitespace between inline-block items), so every
+-- other rule passes through verbatim.
+local function sanitize_book_css_pass(css)
+    local removed = 0
+    -- Scan whole `selector { block }` units (balanced braces); untouched units
+    -- are returned verbatim so no other declaration can be disturbed.
+    local sanitized = css:gsub("([^{}]*)(%b{})", function(prelude, block)
+        -- Text before the last ";" belongs to an at-rule or a previous
+        -- statement, not to this block's selector list.
+        local selectors = prelude:match("[^;]*$") or ""
+        if not is_root_selector_list(selectors) then
+            return prelude .. block
+        end
+        local cleaned, dropped = strip_zero_font_sizes(block:sub(2, -2))
+        removed = removed + dropped
+        return prelude .. "{" .. cleaned .. "}"
+    end)
+    return sanitized, removed
 end
 
 function Content.sanitize_book_css(css)


### PR DESCRIPTION
## 变更说明

修复服务端返回的书籍 CSS 中 `html, body { font-size: 0 }` 导致 KOReader 全书正文塌缩成极小字号的缺陷。新增 `Content.sanitize_book_css`，在 `fetch_chapter_css` 解码样式分片后清洗独立的零字号声明。

相关：#133（调试同一本书时发现的脚注定义污染问题）。

## 类型

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Bugfix 要求

无关联 issue，提供复现步骤。

复现步骤（修复前）：

1. 用插件下载一本 `e_2` 样式分片中含有 `html, body { ...; font-size: 0; }` 的书。实测书目：《天才的責任：維根斯坦傳》繁简版
2. 在 KOReader 中打开该书
3. 现象：全书正文塌缩成接近零的字号，无法阅读，页数远低于该书真实长度
4. 对照：同一本书在微信读书自家 App 与 Apple Books 中显示正常
5. 佐证：手动从缓存的 epub 中删掉这一条声明后，字号立即恢复正常

实测环境：KOReader v2026.07.1，Kindle。

根因：

服务端返回的 `e_2` 样式分片偶尔包含：

```css
html, body { margin: 0; padding: 0; font-size: 0; }
```

微信读书自家 App 与多数阅读器会忽略根元素的字号设置，但 crengine 会认真执行。正文使用 `p { font-size: 1rem }`，一旦根字号归零，全书随之塌缩。

修复：

新增 `Content.sanitize_book_css(css)`，在 `fetch_chapter_css` 解码分片时执行，因此覆盖所有消费路径（整书构建、分章缓存、单章拉取）：

- 移除独立的零字号声明：裸 `0`、任意字母单位（`px/em/rem/vh/...`）、`%`，以及可选的 `!important`。小数字号（如 `0.5rem`）与非零值不受影响
- 迭代至不动点，使相邻声明（`font-size:0;font-size:0`）被全部移除
- 保留块终止符（声明末尾缺少 `;` 时保留 `}`），不触碰 `-webkit-font-size` 这类带前缀的属性，并记录被移除的声明条数

代码内已注明的已知限制：属性名匹配区分大小写（目前观察到的分片均为小写）。

## Feature 要求

不适用，本 PR 为 bugfix，未新增特性。

## 测试

- [x] 已在 KOReader 中手动测试
- [x] 已运行 `bash scripts/run_lua_specs.sh`
- [x] 已运行 `bash scripts/check_lua_namespace.sh`
- [x] 已运行 `luacheck main.lua _meta.lua weread spec`
- [ ] 如涉及插件加载/KOReader 兼容性，已运行或触发 `KOReader integration`
- [ ] 不适用，仅文档或注释变更

测试说明:

```text
新增 spec/content_css_sanitize_spec.lua（+103），覆盖：
真实问题分片样本、同级声明存活、!important、px/%/vh 单位、
小数字号透传、缺少结尾分号的声明、nil 与空字符串透传、
相邻重复声明的不动点处理、注释场景的结构完整性、幂等性。

全套 46 个 Lua spec 通过；check_lua_namespace.sh 无告警；
luacheck main.lua _meta.lua weread spec 无告警。

未触发 KOReader integration 工作流：本 PR 只改动 content.lua 中的
CSS 清洗逻辑，不涉及插件加载路径或 KOReader 兼容性。

设备侧已手动验证：修复后该书字号恢复正常。

已知影响：本次改动之前已下载的 EPUB，磁盘上仍保留有问题的 CSS
（插件按原样使用缓存路径），需重新下载受影响的书籍后才会生效。
```

## 非公开 WeRead API

- [x] 不涉及非公开 WeRead API
- [ ] 已新增或更新可复现的 Python 验证脚本

脚本路径:

```text
不适用
```

复现命令与脱敏结果:

```text
不适用。本 PR 未新增或修改任何 WeRead Web API 调用，
只是在 fetch_chapter_css 解码既有响应之后，对返回的 CSS 文本做清洗。
```

## 模块结构

未新增或移动任何模块。仅修改既有的 `weread/lib/content.lua`，并新增 `spec/content_css_sanitize_spec.lua`。命名空间保持不变，未引入根级 `lib/`、`ui/` 模块，也未引入裸 `lib.*`、`ui.*` 模块键。

## 截图

不适用。本 PR 是渲染缺陷修复，未新增或修改 UI、菜单、弹窗与交互。

## Checklist

- [x] 我已经说明这个 PR 解决的问题或新增的特性。
- [x] 如果是 bugfix，我已经提供复现步骤或关联 issue。
- [x] 如果是新增 UI/交互特性，我已经提供截图或录屏。（不适用：未新增 UI 或交互特性）
- [x] 我没有提交 KOReader `settings/weread.lua`、API key、cookie、token、`x-wrpa-*` 或私人书籍内容。
- [x] 新增或移动的项目 Lua 模块遵循 `weread/lib/`、`weread/ui/` 命名空间规范。（不适用：未新增或移动模块）
- [x] 新增或修复的逻辑包含对应回归测试；若无法自动化，已在测试说明中解释原因。
- [x] 如果修改了用户可见文本，我已经更新 `weread/lib/i18n.lua`。（不适用：未修改用户可见文本）
- [x] 如果修改了菜单结构，我已经同步更新 README 菜单结构。（不适用：未修改菜单结构）
- [x] 如果涉及非公开 WeRead Web API，我已经在 `scripts/` 中提交可独立运行、可复现的 Python 验证脚本，并填写了复现命令和脱敏结果。（不适用：不涉及）
