### PR TITLE
fix(library): refine adaptive cover shelf

### DIFF
--- a/spec/empty_state_face_spec.lua
+++ b/spec/empty_state_face_spec.lua
@@ -120,9 +120,11 @@ for _, name in ipairs({
     "ui/widget/horizontalspan",
     "ui/widget/imagewidget",
     "ui/widget/linewidget",
+    "ui/widget/overlapgroup",
     "ui/widget/titlebar",
     "ui/widget/verticalgroup",
     "ui/widget/verticalspan",
+    "ui/widget/widget",
 }) do
     package.preload[name] = widget_module
 end
@@ -246,6 +248,7 @@ local large_view = LibraryView.show({
 expect(large_view.page_count == 100 and #large_view._item_rows == 10,
     "large bookshelf created more than one page of row widgets")
 
+books[1]._cached = true
 local cover_paths = { [books[1]] = "/covers/one.jpg" }
 local cover_view = LibraryView.show({
     mode = "books", books = books, accounts = {},
@@ -261,6 +264,19 @@ expect(#cover_view._focus_item_rows == 2
 expect(cover_view._item_rows[1]._has_cover == true
         and cover_view._item_rows[2]._has_cover == false,
     "cover bookshelf did not distinguish cached covers from placeholders")
+expect(cover_view._item_rows[1].status == nil,
+    "cover bookshelf retained date or cache status metadata")
+expect(cover_view._item_rows[1]._has_cached_corner == true
+        and cover_view._item_rows[1]._cached_corner_size == 16
+        and cover_view._item_rows[2]._has_cached_corner == false,
+    "cover bookshelf cached corner did not follow download state")
+expect(cover_view._item_rows[1].width == 200
+        and cover_view._item_rows[3].width == 200,
+    "cover bookshelf columns did not fill the complete screen width")
+expect(cover_view._item_rows[1].height == cover_view.cover_cell_height
+        and cover_view._item_rows[4].height
+            == cover_view.cover_content_height - cover_view.cover_cell_height,
+    "cover bookshelf rows did not fill the available content height")
 
 local invalid_page_size_view = LibraryView.show({
     mode = "books", books = books, accounts = {},

--- a/weread/ui/library_view.lua
+++ b/weread/ui/library_view.lua
@@ -14,6 +14,7 @@ local HorizontalSpan = require("ui/widget/horizontalspan")
 local ImageWidget = require("ui/widget/imagewidget")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local LineWidget = require("ui/widget/linewidget")
+local OverlapGroup = require("ui/widget/overlapgroup")
 local ScrollableContainer = require("ui/widget/container/scrollablecontainer")
 local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
@@ -21,12 +22,31 @@ local TitleBar = require("ui/widget/titlebar")
 local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
+local Widget = require("ui/widget/widget")
 local Screen = Device.screen
 local FocusNav = require("weread.ui.focus_nav")
 local I18n = require("weread.lib.i18n")
 local T = require("ffi/util").template
 
 local function _(text) return I18n.tr(text) end
+
+local CachedCorner = Widget:extend{
+    size = 0,
+}
+
+function CachedCorner:init()
+    self.size = math.max(1, math.floor(tonumber(self.size) or 1))
+    self.dimen = Geom:new{ w = self.size, h = self.size }
+end
+
+function CachedCorner:paintTo(bb, x, y)
+    -- A compact, solid dog-ear in the upper-right corner. Drawing it one
+    -- scanline at a time keeps the marker dependency-free and crisp on e-ink.
+    for row = 0, self.size - 1 do
+        local width = self.size - row
+        bb:paintRect(x + row, y + row, width, 1, Blitbuffer.COLOR_BLACK)
+    end
+end
 
 local ShelfRow = InputContainer:extend{
     text = "",
@@ -104,7 +124,7 @@ local CoverCell = InputContainer:extend{
     height = nil,
     cover_path = nil,
     cover_loading = false,
-    status = "",
+    cached = false,
     callback = nil,
     show_parent = nil,
 }
@@ -151,7 +171,7 @@ function CoverCell:init()
         }
         self._has_cover = false
     end
-    local cover = CenterContainer:new{
+    local cover_frame = CenterContainer:new{
         dimen = Geom:new{ w = cover_width, h = cover_height },
         FrameContainer:new{
             width = cover_width,
@@ -166,31 +186,43 @@ function CoverCell:init()
             },
         },
     }
+    local cover_layers = {
+        dimen = Geom:new{ w = cover_width, h = cover_height },
+        cover_frame,
+    }
+    self._has_cached_corner = self.cached == true
+    if self._has_cached_corner then
+        local corner_size = math.max(1, math.min(
+            cover_width,
+            cover_height,
+            Screen:scaleBySize(16)
+        ))
+        local corner = CachedCorner:new{ size = corner_size }
+        corner.overlap_offset = { cover_width - corner_size, 0 }
+        cover_layers[#cover_layers + 1] = corner
+        self._cached_corner_size = corner_size
+    end
+    local cover = OverlapGroup:new(cover_layers)
     local title = self.book.title or self.book.bookId or self.book.book_id or _("Untitled")
     local title_widget = TextWidget:new{
         text = title,
         face = Font:getFace("cfont", 18),
         max_width = cover_width,
     }
-    local status_widget = TextWidget:new{
-        text = self.status or "",
-        face = Font:getFace("cfont", 14),
-        max_width = cover_width,
-    }
     self.frame = FrameContainer:new{
-        width = self.width,
-        height = self.height,
         bordersize = 0,
         radius = 0,
         margin = 0,
-        padding = padding,
+        padding = 0,
         background = Blitbuffer.COLOR_WHITE,
         show_parent = self.show_parent,
-        VerticalGroup:new{
-            align = "center",
-            cover,
-            title_widget,
-            status_widget,
+        CenterContainer:new{
+            dimen = Geom:new{ w = self.width, h = self.height },
+            VerticalGroup:new{
+                align = "center",
+                cover,
+                title_widget,
+            },
         },
     }
     self[1] = self.frame
@@ -355,6 +387,24 @@ function LibraryView:itemStatus(book)
     return status
 end
 
+function LibraryView:preparePagination()
+    local source = self.mode == "public_account"
+        and (self.accounts or {}) or (self.books or {})
+    self.page_size = math.max(1, math.floor(tonumber(self.page_size) or 10))
+    if self.cover_mode and self.mode == "books" then
+        local columns = math.max(1, math.floor(tonumber(self.cover_columns) or 3))
+        local rows = math.max(1, math.floor(tonumber(self.cover_rows) or 2))
+        self.page_size = columns * rows
+    end
+    if self.paged then
+        self.page_count = math.max(1, math.ceil(#source / self.page_size))
+        self.page = math.max(
+            1,
+            math.min(math.floor(tonumber(self.page) or 1), self.page_count)
+        )
+    end
+end
+
 function LibraryView:content()
     local source = self.mode == "public_account"
         and (self.accounts or {}) or (self.books or {})
@@ -364,14 +414,6 @@ function LibraryView:content()
     }
     self._item_rows = {}
     self._focus_item_rows = {}
-    self.page_size = math.max(1, math.floor(tonumber(self.page_size) or 10))
-    if self.paged then
-        self.page_count = math.max(1, math.ceil(#source / self.page_size))
-        self.page = math.max(
-            1,
-            math.min(math.floor(tonumber(self.page) or 1), self.page_count)
-        )
-    end
     if #source == 0 then
         table.insert(content, VerticalSpan:new{ width = Size.padding.large })
         table.insert(content, TextWidget:new{
@@ -389,29 +431,36 @@ function LibraryView:content()
     end
     if self.cover_mode and self.mode == "books" then
         local columns = math.max(1, math.floor(tonumber(self.cover_columns) or 3))
-        local cell_width = math.floor(self.screen_w / columns)
-        local cell_height = math.max(
+        local rows = math.max(1, math.floor(tonumber(self.cover_rows) or 2))
+        local cell_width = math.floor(self.content_width / columns)
+        local cell_height = math.floor(math.max(
             1,
             tonumber(self.cover_cell_height) or math.floor(self.screen_h * 0.28)
-        )
+        ))
+        local grid_height = math.max(cell_height, tonumber(self.cover_content_height)
+            or cell_height * rows)
         local grid_row
         for index = first, last do
             local book = source[index]
             local column = ((index - first) % columns) + 1
+            local row = math.floor((index - first) / columns) + 1
             if column == 1 then
                 grid_row = {}
                 self._focus_item_rows[#self._focus_item_rows + 1] = grid_row
                 table.insert(content, HorizontalGroup:new(grid_row))
             end
-            local width = column == columns and self.screen_w - cell_width * (columns - 1)
+            local width = column == columns
+                and self.content_width - cell_width * (columns - 1)
                 or cell_width
+            local height = row == rows and grid_height - cell_height * (rows - 1)
+                or cell_height
             local cover_cell = CoverCell:new{
                 book = book,
-                status = self:itemStatus(book),
+                cached = book._cached == true,
                 cover_path = self.cover_paths and self.cover_paths[book] or nil,
                 cover_loading = self.cover_loading and self.cover_loading[book] == true,
                 width = width,
-                height = cell_height,
+                height = math.max(1, height),
                 show_parent = self,
                 callback = function()
                     if self.on_select then self.on_select(book, self.mode) end
@@ -505,13 +554,17 @@ function LibraryView:init()
     }
     local tabs = self:tabBar()
     local actions = self:actionBar()
-    -- Build the content first: pagination computes the clamped page count and
-    -- creates only the current page's rows.
-    local content = self:content()
+    self:preparePagination()
     local page_bar = self:pageBar()
-    local scroll_h = self.screen_h - self.title_bar:getHeight()
+    local scroll_h = math.max(1, self.screen_h - self.title_bar:getHeight()
         - tabs:getSize().h - actions:getSize().h
-        - (page_bar and page_bar:getSize().h or 0)
+        - (page_bar and page_bar:getSize().h or 0))
+    if self.cover_mode and self.mode == "books" then
+        local rows = math.max(1, math.floor(tonumber(self.cover_rows) or 2))
+        self.cover_content_height = scroll_h
+        self.cover_cell_height = math.max(1, math.floor(scroll_h / rows))
+    end
+    local content = self:content()
     local scroll = ScrollableContainer:new{
         dimen = Geom:new{ w = self.screen_w, h = scroll_h },
         show_parent = self,


### PR DESCRIPTION
## 变更说明

修复封面书架在不同屏幕尺寸下出现内容溢出和横、纵滚动条的问题，并简化书籍卡片的信息展示：

- 移除封面下方的阅读日期与已下载勾选文本，避免额外状态行挤占网格高度。
- 根据封面书架的实际可用宽高动态均分列宽和行高，最后一列、最后一行吸收像素余数，完整铺满视口。
- 将已下载状态改为封面右上角的小型黑色折角，不占用布局空间。
- 让封面分页数量始终与实际“列数 × 行数”一致。
- 增加回归测试，覆盖元信息移除、下载折角状态以及网格宽高铺满行为。

## 类型

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Bugfix 要求

Fixes #140

修复前，封面卡片底部的日期和下载勾会增加卡片实际高度；网格列宽使用整个屏幕宽度，但内容位于滚动容器中。当垂直内容略微溢出并出现纵向滚动条后，可用宽度进一步缩小，继而触发横向滚动条。

## Feature 要求

不适用，本 PR 为现有封面书架的布局修复。

## 测试

- [x] 已在 KOReader 中手动测试
- [x] 已运行 `bash scripts/run_lua_specs.sh`
- [x] 已运行 `bash scripts/check_lua_namespace.sh`
- [x] 已运行 `luacheck main.lua _meta.lua weread spec`
- [ ] 如涉及插件加载/KOReader 兼容性，已运行或触发 `KOReader integration`
- [ ] 不适用，仅文档或注释变更

测试说明:

```text
- Kindle 实机确认：封面书架不再显示日期和底部下载勾。
- 网格完整铺满可用视口，未再出现横向或纵向滚动条。
- 已下载书籍在封面右上角显示黑色折角，且不影响卡片尺寸。
- 52 个 Lua specs 全部通过。
- 命名空间检查通过。
- Luacheck 检查 118 个文件，0 warnings / 0 errors。
```

## 非公开 WeRead API

- [x] 不涉及非公开 WeRead API
- [ ] 已新增或更新可复现的 Python 验证脚本

脚本路径:

```text
不适用
```

复现命令与脱敏结果:

```text
不适用；本 PR 仅修改本地 UI 布局与回归测试。
```

## 模块结构

项目自有 Lua 模块必须放在 `weread/` 命名空间下：

- 非 UI 模块：`weread/lib/`，使用 `require("weread.lib.<module>")`
- UI 模块：`weread/ui/`，使用 `require("weread.ui.<module>")`
- 禁止新增根级 `lib/`、`ui/` 项目模块或裸 `lib.*`、`ui.*` 模块键
- `require("ui/widget/menu")` 等 KOReader 自带模块不受此限制

本 PR 未新增或移动项目模块，仅在 `weread/ui/library_view.lua` 中使用 KOReader 自带 UI 组件。

## 截图

修复前现象见 #140。修复后已在 Kindle 实机验证：网格铺满可用区域，无横向或纵向滚动条；已下载书籍使用右上角黑色折角标记。

## Checklist

- [x] 我已经说明这个 PR 解决的问题或新增的特性。
- [x] 如果是 bugfix，我已经提供复现步骤或关联 issue。
- [x] 如果是新增 UI/交互特性，我已经提供截图或录屏。（不适用：本 PR 为现有 UI 的 bugfix）
- [x] 我没有提交 KOReader `settings/weread.lua`、API key、cookie、token、`x-wrpa-*` 或私人书籍内容。
- [x] 新增或移动的项目 Lua 模块遵循 `weread/lib/`、`weread/ui/` 命名空间规范。（本 PR 未新增或移动模块）
- [x] 新增或修复的逻辑包含对应回归测试；若无法自动化，已在测试说明中解释原因。
- [x] 如果修改了用户可见文本，我已经更新 `weread/lib/i18n.lua`。（本 PR 未修改用户可见文本）
- [x] 如果修改了菜单结构，我已经同步更新 README 菜单结构。（本 PR 未修改菜单结构）
- [x] 如果涉及非公开 WeRead Web API，我已经在 `scripts/` 中提交可独立运行、可复现的 Python 验证脚本，并填写了复现命令和脱敏结果。（不涉及 API）