### PR TITLE
feat(epub): include book description metadata

### DIFF
--- a/spec/download_disk_assets_spec.lua
+++ b/spec/download_disk_assets_spec.lua
@@ -61,7 +61,7 @@ package.preload["ffi/archiver"] = function()
     end
     function Writer:addFileFromMemory(name, data)
         archive_calls[#archive_calls + 1] = {
-            kind = "memory", name = name, bytes = #data,
+            kind = "memory", name = name, bytes = #data, data = data,
         }
         return true
     end
@@ -193,7 +193,12 @@ local settings = {
     cache_dir = root,
     get = function(_self, _key, default) return default end,
 }
-local book = { book_id = "book", title = "Disk Assets", cache_dir = root }
+local book = {
+    book_id = "book",
+    title = "Disk Assets",
+    intro = "简介 & <精彩> \"引号\"\n第二行\0\1",
+    cache_dir = root,
+}
 local output = Content.save_book_epub(settings, book,
     { { chapterUid = 7, title = "Chapter" } },
     { ["7"] = "<p>body</p>" }, "book", assets, "body{}")
@@ -212,6 +217,19 @@ expect(used_path and path_calls == 1,
     "EPUB writer did not stream the staged image directory with one addPath")
 expect(io.open(output .. ".part", "rb") == nil,
     "successful EPUB build left a partial archive")
+local opf
+for _, call in ipairs(archive_calls) do
+    if call.kind == "memory" and call.name == "OEBPS/content.opf" then
+        opf = call.data
+    end
+end
+expect(opf ~= nil, "full-book EPUB did not contain an OPF package document")
+expect(opf:find(
+    '<dc:description>简介 &amp; &lt;精彩&gt; &quot;引号&quot;\n第二行</dc:description>',
+    1, true) ~= nil,
+    "book introduction was not safely embedded as dc:description")
+expect(opf:find("\0", 1, true) == nil and opf:find("\1", 1, true) == nil,
+    "XML-illegal control characters remained in the OPF metadata")
 
 local old = assert(io.open(output, "wb"))
 old:write("known-good-old-epub")

--- a/weread/lib/content.lua
+++ b/weread/lib/content.lua
@@ -446,6 +446,10 @@ end
 
 local function xml_escape(value)
     value = tostring(value or "")
+    -- XML 1.0 permits tabs, newlines, and carriage returns from the C0 range,
+    -- but rejects the remaining control characters. Book metadata comes from
+    -- remote APIs, so remove those bytes before embedding it in the OPF.
+    value = value:gsub("[%z\1-\8\11\12\14-\31]", "")
     value = value:gsub("&", "&amp;")
     value = value:gsub("<", "&lt;")
     value = value:gsub(">", "&gt;")
@@ -789,6 +793,11 @@ function Content.save_book_epub(settings, book, chapters, chapter_bodies, suffix
     local book_title = book.title or "WeRead"
     local path = dir .. "/" .. filename_safe(book_title .. " - " .. (suffix or "book")) .. ".epub"
     local author = book.author or "WeRead"
+    local description_meta = ""
+    local description = xml_escape(book.intro)
+    if description ~= "" then
+        description_meta = "\n<dc:description>" .. description .. "</dc:description>"
+    end
     local manifest_items = {
         [[<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>]],
         [[<item id="toc" href="toc.ncx" media-type="application/x-dtbncx+xml"/>]],
@@ -851,7 +860,7 @@ function Content.save_book_epub(settings, book, chapters, chapter_bodies, suffix
 <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
 <dc:identifier id="bookid">weread-]] .. xml_escape(book_id) .. [[-]] .. xml_escape(suffix or "book") .. [[</dc:identifier>
 <dc:title>]] .. xml_escape(book_title) .. [[</dc:title>
-<dc:creator>]] .. xml_escape(author) .. [[</dc:creator>
+<dc:creator>]] .. xml_escape(author) .. [[</dc:creator>]] .. description_meta .. [[
 <dc:publisher>WeRead</dc:publisher>
 <dc:source>]] .. xml_escape(WeRead.reader_url(book_id)) .. [[</dc:source>
 <dc:language>zh-CN</dc:language>


### PR DESCRIPTION
## 变更说明

为整本书下载生成的 EPUB 增加书籍简介元数据。

插件已从 `/book/info` 获取并保存 `book.intro`，但此前生成整本 EPUB 时没有将该字段写入 OPF，导致 KOReader 的“书籍信息”中缺少简介。本 PR 在简介非空时写入标准的 `dc:description` 元数据，并过滤 XML 1.0 不允许的控制字符、转义 XML 特殊字符，避免无效元数据破坏 EPUB。

Closes #142

## 类型

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Bugfix 要求

不适用。

## Feature 要求

- 新增能力：整本下载的 EPUB 包含微信读书书籍简介。
- 典型使用场景：在 KOReader 中查看下载书籍的“书籍信息”时，可以直接阅读简介。
- 本变更不涉及 UI、菜单、弹窗、排版或交互，无需截图。

## 测试

- [x] 已在 KOReader 中手动测试
- [x] 已运行 `bash scripts/run_lua_specs.sh`
- [x] 已运行 `bash scripts/check_lua_namespace.sh`
- [x] 已运行 `luacheck main.lua _meta.lua weread spec`
- [ ] 如涉及插件加载/KOReader 兼容性，已运行或触发 `KOReader integration`
- [ ] 不适用，仅文档或注释变更

测试说明:

```text
- 52 个 Lua spec 全部通过
- namespace 检查通过
- Luacheck：118 个文件，0 warnings / 0 errors
- 发布包构建及压缩数据校验通过
- 敏感信息扫描无匹配
- 已同步至 KOReader 设备，重新下载整本书后确认简介可以正常显示
- 回归测试覆盖中文、换行、XML 特殊字符和非法控制字符
```

## 非公开 WeRead API

- [x] 不涉及非公开 WeRead API
- [ ] 已新增或更新可复现的 Python 验证脚本

脚本路径:

```text
不适用
```

复现命令与脱敏结果:

```text
不适用；仅使用现有 book.intro 数据写入 EPUB 元数据。
```

## 模块结构

未新增或移动 Lua 模块。

## 截图

不涉及 UI 或交互变更。

## Checklist

- [x] 我已经说明这个 PR 解决的问题或新增的特性。
- [x] 如果是 bugfix，我已经提供复现步骤或关联 issue。
- [x] 如果是新增 UI/交互特性，我已经提供截图或录屏。
- [x] 我没有提交 KOReader `settings/weread.lua`、API key、cookie、token、`x-wrpa-*` 或私人书籍内容。
- [x] 新增或移动的项目 Lua 模块遵循 `weread/lib/`、`weread/ui/` 命名空间规范。
- [x] 新增或修复的逻辑包含对应回归测试；若无法自动化，已在测试说明中解释原因。
- [x] 如果修改了用户可见文本，我已经更新 `weread/lib/i18n.lua`。
- [x] 如果修改了菜单结构，我已经同步更新 README 菜单结构。
- [x] 如果涉及非公开 WeRead Web API，我已经在 `scripts/` 中提交可独立运行、可复现的 Python 验证脚本，并填写了复现命令和脱敏结果。