### PR TITLE
fix: 修复目录顺序不一致导致的章节匹配跳过

### DIFF
--- a/spec/chapter_mapping_spec.lua
+++ b/spec/chapter_mapping_spec.lua
@@ -1,0 +1,59 @@
+package.path = "./?.lua;" .. package.path
+local Chapters = require("weread.lib.annotation_chapters")
+local toc = {
+    {title="雨季不再来", xpointer="a", depth=1},
+    {title="版权信息", xpointer="b", depth=1},
+    {title="当三毛还是在二毛的时候", xpointer="c", depth=1},
+    {title="胆小鬼", xpointer="d", depth=1},
+    {title="雨季不再来", xpointer="e", depth=1},
+    {title="一个星期一的早晨", xpointer="f", depth=1},
+}
+local catalog = {
+    {chapterUid="2",title="版权信息",level=1},
+    {chapterUid="3",title="雨季不再来",level=1},
+    {chapterUid="4",title="当三毛还是在二毛的时候",level=2},
+    {chapterUid="5",title="胆小鬼",level=2},
+    {chapterUid="21",title="雨季不再来",level=2},
+    {chapterUid="22",title="一个星期一的早晨",level=2},
+}
+local doc={getToc=function() return toc end}
+local selected,ranges=Chapters.map(doc,catalog)
+assert(#selected==#catalog)
+assert(ranges['4'].start_xpointer=='c' and ranges['5'].start_xpointer=='d', 'front chapters skipped')
+assert(not ranges['3'] and not ranges['21'], 'duplicate volume/article guessed')
+local reordered={catalog[6],catalog[4],catalog[3],catalog[1]}
+selected,ranges=Chapters.map(doc,reordered)
+assert(selected[1].chapterUid=='2' and selected[4].chapterUid=='22', 'remote reorder changed local processing order')
+assert(ranges['4'].end_xpointer=='d')
+local nested={
+    {title='第一卷',depth=1,xpointer='1'}, {title='序言',depth=2,xpointer='2'},
+    {title='第二卷',depth=1,xpointer='3'}, {title='序言',depth=2,xpointer='4'},
+}
+local remote={
+    {title='第二卷',level=1,chapterUid='b'}, {title='序言',level=2,chapterUid='bp'},
+    {title='第一卷',level=1,chapterUid='a'}, {title='序言',level=2,chapterUid='ap'},
+}
+local _,nr=Chapters.map({getToc=function() return nested end},remote)
+assert(nr.ap.start_xpointer=='2' and nr.bp.start_xpointer=='4','duplicate parent scopes lost')
+table.insert(remote,{title='序言',level=2,chapterUid='ap2'})
+_,nr=Chapters.map({getToc=function() return nested end},remote)
+assert(not nr.ap and not nr.ap2,'ambiguous siblings assigned by order')
+local _,dr=Chapters.map(doc,catalog,{chapters={catalog[2],catalog[1]}})
+assert(dr['3'].toc_index==1 and dr['2'].toc_index==2,'manifest identity changed')
+-- Reconciliation is document-specific and does not discard source data.
+local helper=require('spec.helpers.annotation_test_store')
+local store=helper.new()
+for _,uid in ipairs({'4','5'}) do
+    local key='doc:'..uid
+    store:put('book','status',key,{range_key=Chapters.rangeKey(ranges[uid])},uid)
+    store:put('book','projection',key,{records={1}},uid)
+    store:put('book','source',uid,{underlines={1}},uid)
+end
+store:put('book','status','other:4',{range_key='other'},'4')
+local old=ranges['4'];ranges['4']={start_xpointer='new',end_xpointer=old.end_xpointer}
+store:reconcileRanges('book','doc',ranges)
+assert(not store:get('book','status','doc:4') and not store:get('book','projection','doc:4'))
+assert(store:get('book','status','doc:5') and store:get('book','status','other:4'))
+assert(store:get('book','source','4').underlines[1]==1)
+helper.cleanup()
+print('chapter_mapping_spec: reorder, duplicate scopes, bounds and cache retention passed')

--- a/weread/lib/annotation_chapters.lua
+++ b/weread/lib/annotation_chapters.lua
@@ -145,86 +145,127 @@ function Chapters.documentEnd(document)
     end
 end
 
+-- Resolve identity independently of catalog order. Only unique names are
+-- automatic; duplicate names need a unique parent context.
 function Chapters.map(document, catalog, descriptor)
     local ok, toc = pcall(document.getToc, document)
     toc = ok and type(toc) == "table" and toc or {}
-    local by_title, by_exact, by_relaxed = {}, {}, {}
-    for index, item in ipairs(toc) do
-        local norm = normalized_chapter_title(item.title)
-        by_title[norm] = by_title[norm] or {}
-        table.insert(by_title[norm], index)
-        local relaxed = relaxed_chapter_title(item.title)
-        by_relaxed[relaxed] = by_relaxed[relaxed] or {}
-        table.insert(by_relaxed[relaxed], index)
-        local exact = tostring(item.title or "")
-        by_exact[exact] = by_exact[exact] or {}
-        table.insert(by_exact[exact], index)
+    catalog = descriptor and descriptor.chapters or catalog
+    local indexes, counts = { {}, {}, {} }, { {}, {}, {} }
+    local function keys(title)
+        return { tostring(title or ""), normalized_chapter_title(title), relaxed_chapter_title(title) }
     end
-    local remote_relaxed_counts = {}
+    local parents, stack = {}, {}
+    for i, entry in ipairs(toc) do
+        local depth = tonumber(entry.depth) or 1
+        while #stack > 0 and (tonumber(toc[stack[#stack]].depth) or 1) >= depth do
+            table.remove(stack)
+        end
+        parents[i] = stack[#stack]
+        stack[#stack + 1] = i
+        for n, key in ipairs(keys(entry.title)) do
+            indexes[n][key] = indexes[n][key] or {}
+            table.insert(indexes[n][key], i)
+        end
+    end
     for _, chapter in ipairs(catalog) do
-        local relaxed = relaxed_chapter_title(chapter.title)
-        remote_relaxed_counts[relaxed] = (remote_relaxed_counts[relaxed] or 0) + 1
+        for n, key in ipairs(keys(chapter.title)) do counts[n][key] = (counts[n][key] or 0) + 1 end
     end
-    local ranges, selected, matched, previous = {}, {}, {}, 0
-    local allowed
-    if descriptor then
-        allowed = {}
-        for _, chapter in ipairs(descriptor.chapters or {}) do
-            allowed[Chapters.uid(chapter)] = true
-        end
-        -- Download manifests are authoritative, including partial/noncontiguous
-        -- selections. Their TOC is generated in exactly the same order.
-        catalog = descriptor.chapters or {}
-    end
-    for index, chapter in ipairs(catalog) do
+    local chosen, occupied, candidates = {}, {}, {}
+    for i, chapter in ipairs(catalog) do
         local uid = Chapters.uid(chapter)
-        local candidates = by_exact[tostring(chapter.title or "")]
-            or by_title[normalized_chapter_title(chapter.title)]
-        if not candidates then
-            local relaxed = relaxed_chapter_title(chapter.title)
-            local local_candidates = by_relaxed[relaxed]
-            -- A relaxed key is safe only when it identifies one chapter on
-            -- both sides. Exact/strict duplicate titles still use TOC order.
-            if remote_relaxed_counts[relaxed] == 1
-                and local_candidates and #local_candidates == 1 then
-                candidates = local_candidates
-            end
-        end
-        candidates = candidates or {}
-        local chosen
-        if descriptor and toc[index] then
-            chosen = index
-        else
-            for _, candidate in ipairs(candidates) do
-                if candidate > previous then chosen = candidate; break end
-            end
-        end
-        if chosen and toc[chosen].xpointer then
-            matched[#matched + 1] = { chapter = chapter, index = chosen }
-            previous = chosen
-        end
-        if not allowed or allowed[uid] then selected[#selected + 1] = chapter end
-    end
-    local doc_end = Chapters.documentEnd(document)
-    for index, match in ipairs(matched) do
-        local entry = toc[match.index]
-        local next_match = matched[index + 1]
-        local end_xp = next_match and toc[next_match.index].xpointer
-        -- Stop at an intervening sibling even if its title could not be
-        -- matched. Child sections belong to this chapter unless they themselves
-        -- are the next matched remote chapter.
-        for j = match.index + 1, next_match and next_match.index or #toc do
-            if (tonumber(toc[j].depth) or 1) <= (tonumber(entry.depth) or 1) then
-                end_xp = toc[j].xpointer
+        local chapter_keys = keys(chapter.title)
+        for n, key in ipairs(chapter_keys) do
+            if indexes[n][key] then
+                candidates[uid] = indexes[n][key]
+                if key ~= "" and not descriptor and #indexes[n][key] == 1 and counts[n][key] == 1 then
+                    local target = indexes[n][key][1]
+                    if not occupied[target] then chosen[uid], occupied[target] = target, uid end
+                end
                 break
             end
         end
+        if descriptor and toc[i] and not occupied[i] then
+            chosen[uid], occupied[i] = i, uid
+        end
+    end
+    -- Resolve duplicate children only inside an already identified parent.
+    -- Avoid quadratic work for pathological catalogs of repeated headings.
+    local scope, scope_counts = {}, {}
+    stack = {}
+    for i, chapter in ipairs(catalog) do
+        local depth = tonumber(chapter.level) or 1
+        while #stack > 0 and (tonumber(catalog[stack[#stack]].level) or 1) >= depth do
+            table.remove(stack)
+        end
+        local uid = Chapters.uid(chapter)
+        scope[uid] = tostring(stack[#stack] or 0) .. "\n" .. normalized_chapter_title(chapter.title)
+        scope_counts[scope[uid]] = (scope_counts[scope[uid]] or 0) + 1
+        stack[#stack + 1] = i
+    end
+    stack = {}
+    for i, chapter in ipairs(catalog) do
+        local depth = tonumber(chapter.level) or 1
+        while #stack > 0 and (tonumber(catalog[stack[#stack]].level) or 1) >= depth do
+            table.remove(stack)
+        end
+        local uid = Chapters.uid(chapter)
+        local parent = stack[#stack] and chosen[Chapters.uid(catalog[stack[#stack]])]
+        local options = candidates[uid] or {}
+        if not chosen[uid] and parent and #options <= 32
+            and scope_counts[scope[uid]] == 1 then
+            local target, ambiguous
+            for _, candidate in ipairs(options) do
+                if parents[candidate] == parent and not occupied[candidate] then
+                    if target then ambiguous = true end
+                    target = candidate
+                end
+            end
+            if target and not ambiguous then
+                chosen[uid], occupied[target] = target, uid
+            end
+        end
+        stack[#stack + 1] = i
+    end
+    local matched, selected, ranges = {}, {}, {}
+    for _, chapter in ipairs(catalog) do
+        local uid = Chapters.uid(chapter)
+        local i = chosen[uid]
+        if i and toc[i].xpointer then matched[#matched + 1] = { chapter = chapter, index = i } end
+    end
+    table.sort(matched, function(a, b) return a.index < b.index end)
+    -- Compute sibling boundaries once, including unmapped local entries.
+    local stops = {}
+    stack = {}
+    for i, entry in ipairs(toc) do
+        while #stack > 0 and (tonumber(toc[stack[#stack]].depth) or 1) >= (tonumber(entry.depth) or 1) do
+            stops[table.remove(stack)] = i
+        end
+        stack[#stack + 1] = i
+    end
+    local doc_end = Chapters.documentEnd(document)
+    for i, match in ipairs(matched) do
+        local entry = toc[match.index]
+        local stop = stops[match.index]
+        local next_match = matched[i + 1]
+        if next_match and (not stop or next_match.index < stop) then stop = next_match.index end
         ranges[Chapters.uid(match.chapter)] = {
-            start_xpointer = entry.xpointer, end_xpointer = end_xp or doc_end,
+            start_xpointer = entry.xpointer, end_xpointer = stop and toc[stop].xpointer or doc_end,
             title = entry.title, toc_index = match.index,
         }
+        selected[#selected + 1] = match.chapter
+    end
+    -- Preserve the existing API's unbound entries; callers filter by ranges.
+    for _, chapter in ipairs(catalog) do
+        if not ranges[Chapters.uid(chapter)] then selected[#selected + 1] = chapter end
     end
     return selected, ranges
+end
+
+-- Versioned range identity also invalidates checkpoints from older algorithms.
+function Chapters.rangeKey(range)
+    if not range then return nil end
+    return "mapping-v2:" .. tostring(range.start_xpointer) .. "\n" .. tostring(range.end_xpointer)
 end
 
 function Chapters.descriptor(book, path)

--- a/weread/lib/annotation_store.lua
+++ b/weread/lib/annotation_store.lua
@@ -90,6 +90,27 @@ function Store:put(book_id, kind, key, value, uid)
     self:write(book_id, { { kind = kind, key = key, value = value, uid = uid } })
 end
 
+-- Invalidate projections whose local chapter boundaries have changed.
+-- Shared downloads, quote indexes and thoughts are deliberately retained.
+function Store:reconcileRanges(book_id, document_key, ranges)
+    local Chapters = require("weread.lib.annotation_chapters")
+    local statuses, changes = self:list(book_id, "status"), {}
+    local prefix = document_key .. ":"
+    for key, status in pairs(statuses) do
+        if key:sub(1, #prefix) == prefix then
+            local uid = key:sub(#prefix + 1)
+            if not ranges[uid] or status.range_key ~= Chapters.rangeKey(ranges[uid]) then
+                for _, kind in ipairs({ "projection", "status", "matching" }) do
+                    changes[#changes + 1] = { kind = kind, key = key }
+                end
+                statuses[key] = nil
+            end
+        end
+    end
+    if #changes > 0 then self:write(book_id, changes) end
+    return statuses
+end
+
 function Store:clearBook(book_id)
     book_id = tostring(book_id or "")
     if book_id == "" then return false, "book id required" end

--- a/weread/lib/annotation_sync.lua
+++ b/weread/lib/annotation_sync.lua
@@ -68,6 +68,7 @@ function Sync:run()
     for index, chapter in ipairs(self.chapters) do
         self.index = index
         local uid = Chapters.uid(chapter)
+        local range_key = Chapters.rangeKey(self.ranges and self.ranges[uid])
         local refreshing = store:get(book_id, "refresh", uid)
         local source_status = store:get(book_id, "source_status", uid)
         if source_status and not refreshing then
@@ -75,7 +76,8 @@ function Sync:run()
                 store:projectionKey(self.document_key, uid))
             if not self.document or (status
                 and status.revision == source_status.revision
-                and status.matcher_version == External.MATCHER_VERSION) then
+                and status.matcher_version == External.MATCHER_VERSION
+                and status.range_key == range_key) then
                 self.completed = self.completed + 1
                 self:yield("saved")
                 goto next_chapter
@@ -167,12 +169,13 @@ function Sync:run()
             local key = store:projectionKey(document_key, uid)
             projection = store:get(book_id, "projection", key)
             if not projection or projection.revision ~= source.revision
-                or projection.matcher_version ~= External.MATCHER_VERSION then
+                or projection.matcher_version ~= External.MATCHER_VERSION
+                or projection.range_key ~= range_key then
                 local match_current = 0
                 self:yield("match", nil, { current = 0, count = #source.underlines })
                 local saved = store:get(book_id, "matching", key)
                 if saved and (saved.revision ~= source.revision
-                    or saved.matcher_version ~= External.MATCHER_VERSION) then
+                    or saved.matcher_version ~= External.MATCHER_VERSION or saved.range_key ~= range_key) then
                     saved = nil
                 end
                 if saved then match_current = math.max(0, (saved.next_index or 1) - 1) end
@@ -186,6 +189,7 @@ function Sync:run()
                         })
                     end,
                     checkpoint = function(state)
+                        state.range_key = range_key
                         state.revision = source.revision
                         state.matcher_version = External.MATCHER_VERSION
                         store:put(book_id, "matching", key, state, uid)
@@ -198,7 +202,7 @@ function Sync:run()
                 -- Keep small position rows in the projection. Thoughts are
                 -- fetched on tap from the shared per-range cache below.
                 for _, record in ipairs(records) do record.items = nil end
-                projection = { revision = source.revision,
+                projection = { revision = source.revision, range_key = range_key,
                     matcher_version = External.MATCHER_VERSION, records = records,
                     stats = stats, complete = true }
             end
@@ -225,7 +229,7 @@ function Sync:run()
             changes[#changes + 1] = { kind = "matching", key = key }
             changes[#changes + 1] = { kind = "status", key = key, uid = uid,
                 value = { stats = projection.stats, revision = projection.revision,
-                    matcher_version = projection.matcher_version } }
+                    matcher_version = projection.matcher_version, range_key = range_key } }
         end
         store:write(book_id, changes)
         self.completed = self.completed + 1

--- a/weread/ui/annotation_sync_controller.lua
+++ b/weread/ui/annotation_sync_controller.lua
@@ -116,7 +116,7 @@ function M:_prepareAnnotationContext(online, refresh_catalog)
     store:importLegacy(book_id, path, document_key)
     context = { path = path, book_id = book_id, binding = binding, book = book,
         store = store, document_key = document_key, chapters = selected, ranges = ranges,
-        descriptor = descriptor, statuses = store:list(book_id, "status") }
+        descriptor = descriptor, statuses = store:reconcileRanges(book_id, document_key, ranges) }
     self._annotation_context = context
     return context
 end


### PR DESCRIPTION
## 变更说明

本地 EPUB 与微信目录顺序不一致时，原匹配逻辑只允许向后查找。同名卷名一旦误配到后面的文章，就会使前面的正文被整段跳过。

改为独立建立章节对应，再按本地目录顺序处理。两边唯一的标题直接对应；重名仅在父级上下文唯一时对应，无法确认时跳过该项。章节范围使用本地目录边界，避免越界匹配。

给定位结果及断点记录章节范围标识，范围变化或旧结果缺少标识时重新定位，保留已拉取的划线、想法和原文缓存。目录使用标题索引，重复标题的候选检查有数量上限；不新增网络请求或全文扫描。

## 类型

- [x] Bugfix

## Bugfix 要求

关联 #156（该 issue 已关闭，本 PR 修复后续设备验证发现的目录顺序问题）。

复现：本地目录为“雨季不再来（卷名）→ 版权信息 → 当三毛还是在二毛的时候 → … → 雨季不再来（文章）”；微信目录先列版权信息，再列卷名。原实现匹配版权信息后，把卷名对应到后面的同名文章，跳过中间正文。回归测试覆盖该情况、目录重排、重名父级、章节边界及缓存保留。

## 测试

- [ ] 已在 KOReader 中手动测试
- [x] 已运行 `bash scripts/run_lua_specs.sh`：67 个通过
- [x] 已运行 `bash scripts/check_lua_namespace.sh`
- [x] 已运行 `luacheck main.lua _meta.lua weread spec`：145 个文件，0 警告、0 错误
- [x] 已触发 [KOReader integration](https://github.com/finlater/weread.koplugin/actions/runs/34705342268)，结果待完成

`git diff --check` 和安装包检查通过。使用设备提取的目录在本机复现，原先跳过的前 18 篇正文现在均能建立对应。已部署到 Kindle，86 个安装文件的 SHA-256 校验一致；尚未收到最终设备手动匹配效果的确认，目录复现不等同于实机匹配验证。

## 非公开 WeRead API

- [x] 不涉及非公开 WeRead API

## 模块结构

改动位于现有 `weread/lib/` 和 `weread/ui/` 模块，新增回归测试 `spec/chapter_mapping_spec.lua`。

## 截图

无界面、菜单或用户可见文本变更。

## Checklist

- [x] 已说明问题、复现步骤并关联原 issue。
- [x] 未提交设置、凭据或私人书籍正文。
- [x] 项目模块遵循命名空间规范。
- [x] 修复逻辑包含回归测试。
- [x] 不涉及 UI、翻译、README 菜单结构或非公开 API 变更。
